### PR TITLE
[FIX] Fix a warning on the SubSection of About section

### DIFF
--- a/src/theme/sections/About.tsx
+++ b/src/theme/sections/About.tsx
@@ -17,6 +17,7 @@ const About = (): JSX.Element => {
 
       {about.map(({ markdown, image, withSeparator }, index) => (
         <SubSection
+          key={index}
           markdown={markdown}
           image={image}
           withSeparator={withSeparator}


### PR DESCRIPTION
`Warning: Each child in a list should have a unique "key" prop`