### PR TITLE
[FEAT] Add blog post 'mxgraph in TS project'

### DIFF
--- a/src/content/PostsContent.tsx
+++ b/src/content/PostsContent.tsx
@@ -33,6 +33,14 @@ const posts: PostDescription[] = [
     time: 11,
   },
   {
+    title: 'mxGraph Usage in TypeScript Projects',
+    text: 'Learn how to integrate mxGraph in TypeScript project. The article also explains how we did it in bpmn-visualization.',
+    cover: 'https://dz2cdn1.dzone.com/thumbnail?fid=14747584&w=400', // from dzone list when searching for the article
+    url: 'https://dzone.com/articles/mxgraph-usage-in-typescript-projects',
+    date: 'May 2021',
+    time: 7,
+  },
+  {
     title:
       'Automated visual regression testing with TypeScript, Playwright and Jest', // original title which would have been truncated: 'Automated visual regression testing with TypeScript, Playwright, Jest and Jest Image Snapshot'
     text: 'Learn how to set up and to run automated visual regression testing with TypeScript, Playwright, Jest and Jest Image Snapshot.',


### PR DESCRIPTION
Size of the image used to present the article: 38kb
With this new entry, we will have 9 referenced blog posts. It becomes urgent implementing #187 