### PR TITLE
[INFRA] Fix Husky installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "clean": "gatsby clean",
     "check-types": "tsc -p . --noEmit",
     "lint": "eslint \"*/**/*.{js,ts,tsx}\" NOTICE --max-warnings 0 --fix",
-    "lint-check": "eslint \"*/**/*.{js,ts,tsx}\" NOTICE --max-warnings 0"
+    "lint-check": "eslint \"*/**/*.{js,ts,tsx}\" NOTICE --max-warnings 0",
+    "prepare": "husky install"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.36",


### PR DESCRIPTION
Following : https://github.com/typicode/husky/commit/68b410341c3e2de320a16541d18ca80f07faa0d5#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R97

Add missing script:
```
// package.json
{
  "scripts": {
    "prepare": "husky install"
  }
}
```
And run it loccaly:
`npm run prepare`
