### PR TITLE
[FEAT] Don't display all the posts in the 'Blog' section of the 'Home' page

### DIFF
--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -21,7 +21,8 @@ import Section from '../theme/components/Section';
 import { PAGE, SECTION } from '../theme/utils/constants';
 import { Heading } from 'rebass/styled-components';
 import Triangle from '../theme/components/Triangle';
-import { PostContainer } from '../theme/sections/Blog';
+import { PostContainer } from '../theme/components/Post';
+import { postsContent } from '../content/PostsContent';
 
 const BlogPage = (): JSX.Element => (
   <Layout title={PAGE.blog}>
@@ -37,7 +38,7 @@ const BlogPage = (): JSX.Element => (
       >
         {SECTION.blog}
       </Heading>
-      <PostContainer />
+      <PostContainer posts={postsContent.posts} />
     </Section.Container>
     <Footer />
   </Layout>

--- a/src/theme/components/Card.tsx
+++ b/src/theme/components/Card.tsx
@@ -39,7 +39,7 @@ export const Card = styled(CardRebass).attrs({
   bg: 'background',
   boxShadow: 0,
 })`
-  border: 1px solid rgba(0, 0, 0, 0.2);
+  border: ${props => props.style?.borderWidth ?? '1px'} solid rgba(0, 0, 0, 0.2);
   position: relative;
   transition: all 0.25s;
   top: 0;

--- a/src/theme/components/Card.tsx
+++ b/src/theme/components/Card.tsx
@@ -39,7 +39,7 @@ export const Card = styled(CardRebass).attrs({
   bg: 'background',
   boxShadow: 0,
 })`
-  border: ${props => props.style?.borderWidth ?? '1px'} solid rgba(0, 0, 0, 0.2);
+  border: 1px solid rgba(0, 0, 0, 0.2);
   position: relative;
   transition: all 0.25s;
   top: 0;

--- a/src/theme/components/Footer.tsx
+++ b/src/theme/components/Footer.tsx
@@ -18,7 +18,7 @@ import styled from 'styled-components';
 import { Box, Flex, Image, Text } from 'rebass/styled-components';
 import { Fade } from 'react-awesome-reveal';
 import SocialLink from './SocialLink';
-import Link from './Link';
+import { Link } from './Link';
 import { GATSBY_URL, MEDIA_QUERY_SMALL } from '../utils/constants';
 import { landing } from '../../content/LandingContent';
 import { header } from '../../content/HeaderContent';

--- a/src/theme/components/Header.tsx
+++ b/src/theme/components/Header.tsx
@@ -23,7 +23,7 @@ import {
   Button,
 } from 'rebass/styled-components';
 import styled from 'styled-components';
-import Link from './Link';
+import { Link } from './Link';
 import { capitalize } from '../utils/string';
 import { SECTION } from '../utils/constants';
 import { getSectionHref } from '../utils/helpers';

--- a/src/theme/components/Link.tsx
+++ b/src/theme/components/Link.tsx
@@ -54,4 +54,12 @@ const Link = styled.a<Props>`
   }
 `;
 
-export default Link;
+const LinkInButton = styled.a`
+  text-decoration: none;
+  display: block;
+  padding: '8px 16px';
+  font-weight: 600;
+  color: inherit;
+`;
+
+export { Link, LinkInButton };

--- a/src/theme/components/PageHeader.tsx
+++ b/src/theme/components/PageHeader.tsx
@@ -25,7 +25,7 @@ import {
 import styled from 'styled-components';
 import { header } from '../../content/HeaderContent';
 import { PAGE } from '../utils/constants';
-import Link from './Link';
+import { Link } from './Link';
 import { capitalize } from '../utils/string';
 
 const PageHeader = (): JSX.Element => {

--- a/src/theme/components/Post.tsx
+++ b/src/theme/components/Post.tsx
@@ -93,7 +93,7 @@ export const PostContainer = ({
         </DownFade>
       </CardContainer>
       {pageId && (
-        <Flex justifyContent="center" mt="3" fontSize={[2, 3]}>
+        <Flex justifyContent="center" mt="4" fontSize={[2, 3]}>
           <DownFade>
             <Button variant="more">
               <RebassLink

--- a/src/theme/components/Post.tsx
+++ b/src/theme/components/Post.tsx
@@ -93,8 +93,8 @@ export const PostContainer = ({
         </DownFade>
       </CardContainer>
       {pageId && (
-        <Flex justifyContent="center" mt="4" mb="2" fontSize={[2, 3]}>
-          <DownFade>
+        <DownFade>
+          <Flex justifyContent="center" mt="4" mb="2" fontSize={[2, 3]}>
             <Button variant="more">
               <RebassLink
                 href={`/${pageId}`}
@@ -104,8 +104,8 @@ export const PostContainer = ({
                 More
               </RebassLink>
             </Button>
-          </DownFade>
-        </Flex>
+          </Flex>
+        </DownFade>
       )}
     </>
   );

--- a/src/theme/components/Post.tsx
+++ b/src/theme/components/Post.tsx
@@ -21,6 +21,7 @@ import { Card, CardContainer } from './Card';
 import CardFooter from './CardFooter';
 import { Fade } from 'react-awesome-reveal';
 import { LinkInButton } from './Link';
+import colors from '../colors.json';
 
 const cardMinWidth = '350px';
 
@@ -98,7 +99,11 @@ export const PostContainer = ({
             <Card
               as={LinkInButton}
               href={`/${pageId}`}
-              style={{ borderWidth: '2px', padding: '8px 70px' }}
+              style={{
+                borderWidth: '2px',
+                padding: '8px 70px',
+                background: colors.background,
+              }}
             >
               More
             </Card>

--- a/src/theme/components/Post.tsx
+++ b/src/theme/components/Post.tsx
@@ -93,7 +93,7 @@ export const PostContainer = ({
         </DownFade>
       </CardContainer>
       {pageId && (
-        <Flex justifyContent="center" mt="4" fontSize={[2, 3]}>
+        <Flex justifyContent="center" mt="4" mb="2" fontSize={[2, 3]}>
           <DownFade>
             <Button variant="more">
               <RebassLink

--- a/src/theme/components/Post.tsx
+++ b/src/theme/components/Post.tsx
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 import React from 'react';
-import { Heading, Text } from 'rebass/styled-components';
+import { Button, Flex, Heading, Text } from 'rebass/styled-components';
 import styled from 'styled-components';
 import { PostDescription } from '../types';
 import { Card, CardContainer } from './Card';
 import CardFooter from './CardFooter';
 import { Fade } from 'react-awesome-reveal';
 import { cardMinWidth } from '../sections/Blog';
+import { Link as RebassLink } from 'rebass';
 
 type PostProps = PostDescription;
 
@@ -87,6 +88,20 @@ export const PostContainer = ({
         {(displayAll ? posts : posts.slice(0, 6)).map(p => (
           <Post {...p} key={p.url} />
         ))}
+        {!displayAll && (
+          <Flex width="100%" justifyContent="end">
+            <Button variant="secondary">
+              <RebassLink
+                href="https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/index.html"
+                target="_blank"
+                color="inherit"
+                style={{ textDecorationLine: 'inherit' }}
+              >
+                More
+              </RebassLink>
+            </Button>
+          </Flex>
+        )}
       </Fade>
     </CardContainer>
   );

--- a/src/theme/components/Post.tsx
+++ b/src/theme/components/Post.tsx
@@ -97,7 +97,7 @@ export const PostContainer = ({
         <DownFade>
           <Flex justifyContent="center" mt="4" mb="2" fontSize={[2, 3]}>
             <MoreButton>
-              <StyledLink href={`/${pageId}`}>More</StyledLink>
+              <Link href={`/${pageId}`}>More</Link>
             </MoreButton>
           </Flex>
         </DownFade>
@@ -112,14 +112,11 @@ const DownFade = ({ children }: { children: ReactNode }): JSX.Element => (
   </Fade>
 );
 
-const StyledLink = styled(Link)``;
 const MoreButton = styled(Card)`
   border-width: 2px;
   padding: 0;
-  color: ${colors.text};
-  background: ${colors.background};
 
-  ${StyledLink} {
+  & > a {
     text-decoration: none;
     display: block;
     padding: 8px 70px;

--- a/src/theme/components/Post.tsx
+++ b/src/theme/components/Post.tsx
@@ -20,8 +20,6 @@ import { PostDescription } from '../types';
 import { Card, CardContainer } from './Card';
 import CardFooter from './CardFooter';
 import { Fade } from 'react-awesome-reveal';
-import { Link } from 'rebass';
-import colors from '../colors.json';
 
 const cardMinWidth = '350px';
 
@@ -96,8 +94,8 @@ export const PostContainer = ({
       {pageId && (
         <DownFade>
           <Flex justifyContent="center" mt="4" mb="2" fontSize={[2, 3]}>
-            <MoreButton>
-              <Link href={`/${pageId}`}>More</Link>
+            <MoreButton as="a" href={`/${pageId}`}>
+              More
             </MoreButton>
           </Flex>
         </DownFade>
@@ -116,11 +114,9 @@ const MoreButton = styled(Card)`
   border-width: 2px;
   padding: 0;
 
-  & > a {
-    text-decoration: none;
-    display: block;
-    padding: 8px 70px;
-    font-weight: 600;
-    color: inherit;
-  }
+  text-decoration: none;
+  display: block;
+  padding: 8px 70px;
+  font-weight: 600;
+  color: inherit;
 `;

--- a/src/theme/components/Post.tsx
+++ b/src/theme/components/Post.tsx
@@ -93,7 +93,7 @@ export const PostContainer = ({
         </DownFade>
       </CardContainer>
       {pageId && (
-        <Flex justifyContent="end" mt="3" fontSize={[2, 3]}>
+        <Flex justifyContent="center" mt="3" fontSize={[2, 3]}>
           <DownFade>
             <Button variant="more">
               <RebassLink

--- a/src/theme/components/Post.tsx
+++ b/src/theme/components/Post.tsx
@@ -17,8 +17,10 @@ import React from 'react';
 import { Heading, Text } from 'rebass/styled-components';
 import styled from 'styled-components';
 import { PostDescription } from '../types';
-import { Card } from './Card';
+import { Card, CardContainer } from './Card';
 import CardFooter from './CardFooter';
+import { Fade } from 'react-awesome-reveal';
+import { cardMinWidth } from '../sections/Blog';
 
 type PostProps = PostDescription;
 
@@ -69,3 +71,19 @@ const EllipsisHeading = styled(Heading)`
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
 `;
+
+type PostContainerProps = {
+  posts: PostDescription[];
+};
+
+export const PostContainer = ({ posts }: PostContainerProps): JSX.Element => {
+  return (
+    <CardContainer minWidth={cardMinWidth}>
+      <Fade direction="down" triggerOnce cascade damping={0.5}>
+        {posts.map(p => (
+          <Post {...p} key={p.url} />
+        ))}
+      </Fade>
+    </CardContainer>
+  );
+};

--- a/src/theme/components/Post.tsx
+++ b/src/theme/components/Post.tsx
@@ -95,9 +95,9 @@ export const PostContainer = ({
         <DownFade>
           <Flex justifyContent="center" mt="4" mb="2" fontSize={[2, 3]}>
             <Card
-              as={MoreButton}
+              as={LinkInButton}
               href={`/${pageId}`}
-              style={{ borderWidth: '2px' }}
+              style={{ borderWidth: '2px', padding: '8px 70px' }}
             >
               More
             </Card>
@@ -114,10 +114,10 @@ const DownFade = ({ children }: { children: ReactNode }): JSX.Element => (
   </Fade>
 );
 
-const MoreButton = styled.a`
+const LinkInButton = styled.a`
   text-decoration: none;
   display: block;
-  padding: 8px 70px;
+  padding: ${props => props.style?.padding ?? '8px 16px'};
   font-weight: 600;
   color: inherit;
 `;

--- a/src/theme/components/Post.tsx
+++ b/src/theme/components/Post.tsx
@@ -94,9 +94,13 @@ export const PostContainer = ({
       {pageId && (
         <DownFade>
           <Flex justifyContent="center" mt="4" mb="2" fontSize={[2, 3]}>
-            <MoreButton as="a" href={`/${pageId}`}>
+            <Card
+              as={MoreButton}
+              href={`/${pageId}`}
+              style={{ borderWidth: '2px' }}
+            >
               More
-            </MoreButton>
+            </Card>
           </Flex>
         </DownFade>
       )}
@@ -110,10 +114,7 @@ const DownFade = ({ children }: { children: ReactNode }): JSX.Element => (
   </Fade>
 );
 
-const MoreButton = styled(Card)`
-  border-width: 2px;
-  padding: 0;
-
+const MoreButton = styled.a`
   text-decoration: none;
   display: block;
   padding: 8px 70px;

--- a/src/theme/components/Post.tsx
+++ b/src/theme/components/Post.tsx
@@ -20,8 +20,9 @@ import { PostDescription } from '../types';
 import { Card, CardContainer } from './Card';
 import CardFooter from './CardFooter';
 import { Fade } from 'react-awesome-reveal';
-import { cardMinWidth } from '../sections/Blog';
 import { Link as RebassLink } from 'rebass';
+
+const cardMinWidth = '350px';
 
 type PostProps = PostDescription;
 

--- a/src/theme/components/Post.tsx
+++ b/src/theme/components/Post.tsx
@@ -76,29 +76,28 @@ const EllipsisHeading = styled(Heading)`
 
 type PostContainerProps = {
   posts: PostDescription[];
-  displayAll?: boolean;
+  pageId?: string;
 };
 
 export const PostContainer = ({
   posts,
-  displayAll,
+  pageId,
 }: PostContainerProps): JSX.Element => {
   return (
     <>
       <CardContainer minWidth={cardMinWidth}>
         <DownFade>
-          {(displayAll ? posts : posts.slice(0, 6)).map(p => (
+          {(pageId ? posts.slice(0, 6) : posts).map(p => (
             <Post {...p} key={p.url} />
           ))}
         </DownFade>
       </CardContainer>
-      {displayAll === false && (
+      {pageId && (
         <Flex justifyContent="end" mt="3" fontSize={[2, 3]}>
           <DownFade>
             <Button variant="secondary">
               <RebassLink
-                href="https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/index.html"
-                target="_blank"
+                href={`/${pageId}`}
                 color="inherit"
                 style={{ textDecorationLine: 'inherit' }}
               >

--- a/src/theme/components/Post.tsx
+++ b/src/theme/components/Post.tsx
@@ -20,6 +20,7 @@ import { PostDescription } from '../types';
 import { Card, CardContainer } from './Card';
 import CardFooter from './CardFooter';
 import { Fade } from 'react-awesome-reveal';
+import { LinkInButton } from './Link';
 
 const cardMinWidth = '350px';
 
@@ -113,11 +114,3 @@ const DownFade = ({ children }: { children: ReactNode }): JSX.Element => (
     {children}
   </Fade>
 );
-
-const LinkInButton = styled.a`
-  text-decoration: none;
-  display: block;
-  padding: '8px 16px';
-  font-weight: 600;
-  color: inherit;
-`;

--- a/src/theme/components/Post.tsx
+++ b/src/theme/components/Post.tsx
@@ -95,7 +95,7 @@ export const PostContainer = ({
       {pageId && (
         <Flex justifyContent="end" mt="3" fontSize={[2, 3]}>
           <DownFade>
-            <Button variant="secondary">
+            <Button variant="more">
               <RebassLink
                 href={`/${pageId}`}
                 color="inherit"

--- a/src/theme/components/Post.tsx
+++ b/src/theme/components/Post.tsx
@@ -117,7 +117,7 @@ const DownFade = ({ children }: { children: ReactNode }): JSX.Element => (
 const LinkInButton = styled.a`
   text-decoration: none;
   display: block;
-  padding: ${props => props.style?.padding ?? '8px 16px'};
+  padding: '8px 16px';
   font-weight: 600;
   color: inherit;
 `;

--- a/src/theme/components/Post.tsx
+++ b/src/theme/components/Post.tsx
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 import React, { ReactNode } from 'react';
-import { Button, Flex, Heading, Text } from 'rebass/styled-components';
+import { Flex, Heading, Text } from 'rebass/styled-components';
 import styled from 'styled-components';
 import { PostDescription } from '../types';
 import { Card, CardContainer } from './Card';
 import CardFooter from './CardFooter';
 import { Fade } from 'react-awesome-reveal';
-import { Link as RebassLink } from 'rebass';
+import { Link } from 'rebass';
+import colors from '../colors.json';
 
 const cardMinWidth = '350px';
 
@@ -95,15 +96,9 @@ export const PostContainer = ({
       {pageId && (
         <DownFade>
           <Flex justifyContent="center" mt="4" mb="2" fontSize={[2, 3]}>
-            <Button variant="more">
-              <RebassLink
-                href={`/${pageId}`}
-                color="inherit"
-                style={{ textDecorationLine: 'inherit' }}
-              >
-                More
-              </RebassLink>
-            </Button>
+            <MoreButton>
+              <StyledLink href={`/${pageId}`}>More</StyledLink>
+            </MoreButton>
           </Flex>
         </DownFade>
       )}
@@ -116,3 +111,19 @@ const DownFade = ({ children }: { children: ReactNode }): JSX.Element => (
     {children}
   </Fade>
 );
+
+const StyledLink = styled(Link)``;
+const MoreButton = styled(Card)`
+  border-width: 2px;
+  padding: 0;
+  color: ${colors.text};
+  background: ${colors.background};
+
+  ${StyledLink} {
+    text-decoration: none;
+    display: block;
+    padding: 8px 70px;
+    font-weight: 600;
+    color: inherit;
+  }
+`;

--- a/src/theme/components/Post.tsx
+++ b/src/theme/components/Post.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { Button, Flex, Heading, Text } from 'rebass/styled-components';
 import styled from 'styled-components';
 import { PostDescription } from '../types';
@@ -83,13 +83,17 @@ export const PostContainer = ({
   displayAll,
 }: PostContainerProps): JSX.Element => {
   return (
-    <CardContainer minWidth={cardMinWidth}>
-      <Fade direction="down" triggerOnce cascade damping={0.5}>
-        {(displayAll ? posts : posts.slice(0, 6)).map(p => (
-          <Post {...p} key={p.url} />
-        ))}
-        {!displayAll && (
-          <Flex width="100%" justifyContent="end">
+    <>
+      <CardContainer minWidth={cardMinWidth}>
+        <DownFade>
+          {(displayAll ? posts : posts.slice(0, 6)).map(p => (
+            <Post {...p} key={p.url} />
+          ))}
+        </DownFade>
+      </CardContainer>
+      {displayAll === false && (
+        <Flex justifyContent="end" mt="3">
+          <DownFade>
             <Button variant="secondary">
               <RebassLink
                 href="https://cdn.statically.io/gh/process-analytics/bpmn-visualization-examples/master/examples/index.html"
@@ -100,9 +104,15 @@ export const PostContainer = ({
                 More
               </RebassLink>
             </Button>
-          </Flex>
-        )}
-      </Fade>
-    </CardContainer>
+          </DownFade>
+        </Flex>
+      )}
+    </>
   );
 };
+
+const DownFade = ({ children }: { children: ReactNode }): JSX.Element => (
+  <Fade direction="down" triggerOnce cascade damping={0.5}>
+    {children}
+  </Fade>
+);

--- a/src/theme/components/Post.tsx
+++ b/src/theme/components/Post.tsx
@@ -93,7 +93,7 @@ export const PostContainer = ({
         </DownFade>
       </CardContainer>
       {displayAll === false && (
-        <Flex justifyContent="end" mt="3">
+        <Flex justifyContent="end" mt="3" fontSize={[2, 3]}>
           <DownFade>
             <Button variant="secondary">
               <RebassLink

--- a/src/theme/components/Post.tsx
+++ b/src/theme/components/Post.tsx
@@ -74,13 +74,17 @@ const EllipsisHeading = styled(Heading)`
 
 type PostContainerProps = {
   posts: PostDescription[];
+  displayAll?: boolean;
 };
 
-export const PostContainer = ({ posts }: PostContainerProps): JSX.Element => {
+export const PostContainer = ({
+  posts,
+  displayAll,
+}: PostContainerProps): JSX.Element => {
   return (
     <CardContainer minWidth={cardMinWidth}>
       <Fade direction="down" triggerOnce cascade damping={0.5}>
-        {posts.map(p => (
+        {(displayAll ? posts : posts.slice(0, 6)).map(p => (
           <Post {...p} key={p.url} />
         ))}
       </Fade>

--- a/src/theme/components/Post.tsx
+++ b/src/theme/components/Post.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { Heading, Text } from 'rebass/styled-components';
 import styled from 'styled-components';
 import { PostDescription } from '../types';
@@ -30,36 +30,6 @@ export const Post = ({
   date,
   time,
 }: PostProps): JSX.Element => (
-  <PostContainer url={url} title={title}>
-    <EllipsisHeading m={3} color="text" fontSize={3}>
-      {title}
-    </EllipsisHeading>
-    {cover && <CoverImage src={cover} alt={title} />}
-    <Text m={3} color="text">
-      {text}
-    </Text>
-    <CardFooter bg="primary" color="background" position="bottom-right" round>
-      <span>{`${date} - `}</span>
-      <TimeReadSpan>{`${Math.ceil(time)} min read`}</TimeReadSpan>
-    </CardFooter>
-  </PostContainer>
-);
-
-const TimeReadSpan = styled.span`
-  text-transform: none;
-`;
-
-type PostContainerProps = {
-  url: string;
-  title: string;
-  children: ReactNode;
-};
-
-const PostContainer = ({
-  url,
-  title,
-  children,
-}: PostContainerProps): JSX.Element => (
   <a
     href={url}
     target="__blank"
@@ -67,10 +37,24 @@ const PostContainer = ({
     style={{ textDecoration: 'none' }}
   >
     <Card p={0} pb={4}>
-      {children}
+      <EllipsisHeading m={3} color="text" fontSize={3}>
+        {title}
+      </EllipsisHeading>
+      {cover && <CoverImage src={cover} alt={title} />}
+      <Text m={3} color="text">
+        {text}
+      </Text>
+      <CardFooter bg="primary" color="background" position="bottom-right" round>
+        <span>{`${date} - `}</span>
+        <TimeReadSpan>{`${Math.ceil(time)} min read`}</TimeReadSpan>
+      </CardFooter>
     </Card>
   </a>
 );
+
+const TimeReadSpan = styled.span`
+  text-transform: none;
+`;
 
 const CoverImage = styled.img`
   width: 100%;

--- a/src/theme/components/Section.tsx
+++ b/src/theme/components/Section.tsx
@@ -17,7 +17,7 @@ import React, { ReactNode } from 'react';
 import styled from 'styled-components';
 import { Heading } from 'rebass/styled-components';
 import { Slide } from 'react-awesome-reveal';
-import Link from './Link';
+import { Link } from './Link';
 import { MEDIA_QUERY_SMALL, SECTION } from '../utils/constants';
 import { getSectionHref } from '../utils/helpers';
 

--- a/src/theme/rebass-preset.d.ts
+++ b/src/theme/rebass-preset.d.ts
@@ -146,9 +146,8 @@ declare module '@rebass/preset' {
     variant?: string;
     color?: string;
     bg?: string;
-    border?: number;
+    border?: number | string;
     borderRadius?: string;
-    borderColor?: string;
     textDecoration?: string;
     fontSize?: number;
     fontWeight?: string;

--- a/src/theme/rebass-preset.d.ts
+++ b/src/theme/rebass-preset.d.ts
@@ -141,7 +141,7 @@ declare module '@rebass/preset' {
   }
 
   interface Button {
-    p?: number;
+    p?: number | string;
     m?: number;
     variant?: string;
     color?: string;

--- a/src/theme/rebass-preset.d.ts
+++ b/src/theme/rebass-preset.d.ts
@@ -137,7 +137,6 @@ declare module '@rebass/preset' {
     outline?: Button;
     secondary?: Button;
     empty?: Button;
-    more?: Button;
   }
 
   interface Button {

--- a/src/theme/rebass-preset.d.ts
+++ b/src/theme/rebass-preset.d.ts
@@ -137,6 +137,7 @@ declare module '@rebass/preset' {
     outline?: Button;
     secondary?: Button;
     empty?: Button;
+    more?: Button;
   }
 
   interface Button {
@@ -147,7 +148,8 @@ declare module '@rebass/preset' {
     bg?: string;
     border?: number;
     borderRadius?: string;
-    textDecorationLine?: string;
+    borderColor?: string;
+    textDecoration?: string;
     fontSize?: number;
     fontWeight?: string;
     boxShadow?: string;

--- a/src/theme/sections/Blog.tsx
+++ b/src/theme/sections/Blog.tsx
@@ -23,7 +23,7 @@ import { PostContainer } from '../components/Post';
 const Blog = (): JSX.Element => (
   <Section.Container id={SECTION.blog} Background={Background}>
     <Section.Header name={SECTION.blog} />
-    <PostContainer posts={postsContent.posts} displayAll={false} />
+    <PostContainer posts={postsContent.posts} pageId="blog" />
   </Section.Container>
 );
 

--- a/src/theme/sections/Blog.tsx
+++ b/src/theme/sections/Blog.tsx
@@ -20,8 +20,6 @@ import { SECTION } from '../utils/constants';
 import { postsContent } from '../../content/PostsContent';
 import { PostContainer } from '../components/Post';
 
-export const cardMinWidth = '350px';
-
 const Blog = (): JSX.Element => (
   <Section.Container id={SECTION.blog} Background={Background}>
     <Section.Header name={SECTION.blog} />

--- a/src/theme/sections/Blog.tsx
+++ b/src/theme/sections/Blog.tsx
@@ -25,7 +25,7 @@ export const cardMinWidth = '350px';
 const Blog = (): JSX.Element => (
   <Section.Container id={SECTION.blog} Background={Background}>
     <Section.Header name={SECTION.blog} />
-    <PostContainer posts={postsContent.posts} />
+    <PostContainer posts={postsContent.posts} displayAll={false} />
   </Section.Container>
 );
 

--- a/src/theme/sections/Blog.tsx
+++ b/src/theme/sections/Blog.tsx
@@ -14,35 +14,20 @@
  * limitations under the License.
  */
 import React from 'react';
-import { Fade } from 'react-awesome-reveal';
 import Section from '../components/Section';
-import { CardContainer } from '../components/Card';
 import Triangle from '../components/Triangle';
-import { Post } from '../components/Post';
 import { SECTION } from '../utils/constants';
 import { postsContent } from '../../content/PostsContent';
+import { PostContainer } from '../components/Post';
 
 export const cardMinWidth = '350px';
 
 const Blog = (): JSX.Element => (
   <Section.Container id={SECTION.blog} Background={Background}>
     <Section.Header name={SECTION.blog} />
-    <PostContainer />
+    <PostContainer posts={postsContent.posts} />
   </Section.Container>
 );
-
-const PostContainer = (): JSX.Element => {
-  const { posts } = postsContent;
-  return (
-    <CardContainer minWidth={cardMinWidth}>
-      <Fade direction="down" triggerOnce cascade damping={0.5}>
-        {posts.map(p => (
-          <Post {...p} key={p.url} />
-        ))}
-      </Fade>
-    </CardContainer>
-  );
-};
 
 const Background = (): JSX.Element => (
   <>
@@ -69,4 +54,4 @@ const Background = (): JSX.Element => (
   </>
 );
 
-export { Blog, PostContainer };
+export { Blog };

--- a/src/theme/sections/News.tsx
+++ b/src/theme/sections/News.tsx
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 import React from 'react';
-import { Fade } from 'react-awesome-reveal';
 import Section from '../components/Section';
-import { CardContainer } from '../components/Card';
 import Triangle from '../components/Triangle';
-import { Post } from '../components/Post';
+import { PostContainer } from '../components/Post';
 import { SECTION } from '../utils/constants';
 import { newsContent } from '../../content/NewsContent';
-import { cardMinWidth } from './Blog';
 
 const News = (): JSX.Element => {
   const { news } = newsContent;
@@ -29,13 +26,7 @@ const News = (): JSX.Element => {
   return (
     <Section.Container id={SECTION.news} Background={Background}>
       <Section.Header name={SECTION.news} />
-      <CardContainer minWidth={cardMinWidth}>
-        <Fade direction="down" triggerOnce cascade damping={0.5}>
-          {news.map(p => (
-            <Post {...p} key={p.url} />
-          ))}
-        </Fade>
-      </CardContainer>
+      <PostContainer posts={news} />
     </Section.Container>
   );
 };

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -38,15 +38,6 @@ export const theme: Theme = {
       bg: colors.secondary,
       fontWeight: '600',
     },
-    more: {
-      textDecoration: 'none',
-      color: colors.primary,
-      bg: colors.background,
-      fontWeight: '600',
-      border: `3px solid ${colors.secondary}`,
-      boxShadow: `inset 0 0 2px ${colors.muted}`,
-      p: '8px 10%',
-    },
   },
   fonts: {
     body: 'Cabin, Open Sans, sans-serif',

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -40,11 +40,11 @@ export const theme: Theme = {
     },
     more: {
       textDecoration: 'none',
-      color: colors.secondary,
+      color: colors.primary,
       bg: colors.background,
       fontWeight: '600',
-      border: `1px solid ${colors.text}`,
-      //  boxShadow: `inset 0 0 4px ${colors.text}`,
+      border: `3px solid ${colors.secondary}`,
+      boxShadow: `inset 0 0 2px ${colors.muted}`,
     },
   },
   fonts: {

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -43,7 +43,7 @@ export const theme: Theme = {
       color: colors.secondary,
       bg: colors.background,
       fontWeight: '600',
-      boxShadow: `inset 0 0 5px ${colors.muted}`,
+      boxShadow: `inset 0 0 4px ${colors.text}`,
     },
   },
   fonts: {

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -40,10 +40,10 @@ export const theme: Theme = {
     },
     more: {
       textDecoration: 'none',
-      color: colors.text,
+      color: colors.secondary,
       bg: colors.background,
       fontWeight: '600',
-      boxShadow: `inset 0 0 5px ${colors.primary}`,
+      boxShadow: `inset 0 0 5px ${colors.muted}`,
     },
   },
   fonts: {

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -45,6 +45,7 @@ export const theme: Theme = {
       fontWeight: '600',
       border: `3px solid ${colors.secondary}`,
       boxShadow: `inset 0 0 2px ${colors.muted}`,
+      p: '8px 10%',
     },
   },
   fonts: {

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -43,7 +43,7 @@ export const theme: Theme = {
       color: colors.secondary,
       bg: colors.background,
       fontWeight: '600',
-      border: '1px solid rgba(0,0,0,0.2)',
+      border: `1px solid ${colors.text}`,
       //  boxShadow: `inset 0 0 4px ${colors.text}`,
     },
   },

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -33,10 +33,17 @@ export const theme: Theme = {
       bg: 'transparent',
     },
     secondary: {
-      textDecorationLine: 'none',
+      textDecoration: 'none',
       color: colors.background,
       bg: colors.secondary,
       fontWeight: '600',
+    },
+    more: {
+      textDecoration: 'none',
+      color: colors.text,
+      bg: colors.background,
+      fontWeight: '600',
+      boxShadow: 'inset 0 0 4px red',
     },
   },
   fonts: {

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -43,7 +43,8 @@ export const theme: Theme = {
       color: colors.secondary,
       bg: colors.background,
       fontWeight: '600',
-      boxShadow: `inset 0 0 4px ${colors.text}`,
+      border: '1px solid rgba(0,0,0,0.2)',
+      //  boxShadow: `inset 0 0 4px ${colors.text}`,
     },
   },
   fonts: {

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -43,7 +43,7 @@ export const theme: Theme = {
       color: colors.text,
       bg: colors.background,
       fontWeight: '600',
-      boxShadow: 'inset 0 0 4px red',
+      boxShadow: `inset 0 0 5px ${colors.primary}`,
     },
   },
   fonts: {


### PR DESCRIPTION
Covers #187 

- Remove duplication between `Post` and `News` sections
  - Merge `Post` and old `PostContainer` classes
  - Add a content property in new `PostContainer` class: posts or news can be passed to the component
- The new `PostContainer` class has a new `pageId` property: when set, it limits the number of cards to 6 and create a 'More' button linked to the page passed as property