### PR TITLE
[FEAT] Simplify header in non 'home' pages

### DIFF
--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -21,9 +21,13 @@ import Triangle from '../theme/components/Triangle';
 import { Link } from 'gatsby';
 import Img from '../images/404.png';
 import { PAGE } from '../theme/utils/constants';
+import PageHeader from '../theme/components/PageHeader';
+import Footer from '../theme/components/Footer';
+import { MailingListSubscription } from '../theme/components/mailingListSubscription/MailingListSubscription';
 
 const NotFoundPage = (): JSX.Element => (
   <Layout title={PAGE.notFound}>
+    <PageHeader />
     <Section.Container Background={Background}>
       <Box width={[320, 400, 600]} m="auto">
         <Image
@@ -43,13 +47,16 @@ const NotFoundPage = (): JSX.Element => (
         </Text>
       </Box>
     </Section.Container>
+    <Footer />
+    <MailingListSubscription />
   </Layout>
 );
 
 const Background = (): JSX.Element => (
   <>
     <Triangle
-      color="muted"
+      color="secondary"
+      // color="muted"
       height={['35vh', '80vh']}
       width={['95vw', '60vw']}
     />
@@ -62,7 +69,7 @@ const Background = (): JSX.Element => (
     />
 
     <Triangle
-      color="secondary"
+      color="muted"
       height={['10vh', '20vh']}
       width={['50vw', '50vw']}
       position="top-right"

--- a/src/theme/components/PageHeader.tsx
+++ b/src/theme/components/PageHeader.tsx
@@ -24,9 +24,7 @@ import {
 } from 'rebass/styled-components';
 import styled from 'styled-components';
 import { header } from '../../content/HeaderContent';
-import { PAGE } from '../utils/constants';
-import { Link, LinkInButton } from './Link';
-import { capitalize } from '../utils/string';
+import { LinkInButton } from './Link';
 import colors from '../colors.json';
 
 const PageHeader = (): JSX.Element => {

--- a/src/theme/components/PageHeader.tsx
+++ b/src/theme/components/PageHeader.tsx
@@ -53,22 +53,6 @@ const PageHeader = (): JSX.Element => {
           </Flex>
         </RebassLink>
         <Flex mr={[0, 3, 5]}>
-          {Object.keys(PAGE)
-            .filter(id => id !== 'home' && id !== 'notFound')
-            .map(id => (
-              <Box
-                key={id}
-                ml={[2, 3]}
-                mt="auto"
-                mb="auto"
-                color="background"
-                fontSize={[2, 3]}
-              >
-                <Link href={`/${id}`} tabIndex={0}>
-                  {capitalize(id)}
-                </Link>
-              </Box>
-            ))}
           <Box ml={[2, 3]} fontSize={[2, 3]}>
             <Button
               as={LinkInButton}


### PR DESCRIPTION
In blog and news pages: remove links to posts and news in header
Use header, footer and mail subscription in the 404 page

covers #187