### PR TITLE
[FEAT] Add the December 2021 project news

### DIFF
--- a/src/content/NewsContent.tsx
+++ b/src/content/NewsContent.tsx
@@ -17,6 +17,14 @@ import { PostDescription } from '../theme/types';
 
 const news: PostDescription[] = [
   {
+    title: 'December 2021 Newsletter',
+    text: 'Learn about the website changes and improvements in the BPMN Visualization Typescript library.',
+    cover: 'https://miro.medium.com/max/800/0*uVMqQZHCS3Fg0-T8',
+    url: 'https://medium.com/@process-analytics/process-analytics-december-2021-newsletter-89459219f151',
+    date: 'January 2022',
+    time: 4,
+  },
+  {
     title: 'November 2021 Newsletter',
     text: 'Learn about the website changes and improvements in the BPMN Visualization Typescript library.',
     cover: 'https://miro.medium.com/max/450/0*pTAacquotB7OIAgV',


### PR DESCRIPTION
We now have more than 6 news, so the 'See All' button appear below the 'News' cards in the Home page.

### Screenshots

![image](https://user-images.githubusercontent.com/27200110/148782461-3528b15d-6970-4383-bd36-9e9825408242.png)
