### PR TITLE
 [INFRA] Disable dependabot PR auto rebase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 2
     versioning-strategy: increase
+    rebase-strategy: "disabled"
     commit-message:
       prefix: "[INFRA]"
       prefix-development: "[INFRA] dev -"


### PR DESCRIPTION
Automatic rebases triggered too much GH Actions run, in particular for PR that are on hold because they require manual tests or changes (on breaking changes).
They used a lot of runners so we had job in queue for PR that we wanted to merge in priority.
Now, we ask dependabot to rebase a PR just prior we want to merge it.

**Notes**
Followup of https://github.com/process-analytics/bpmn-visualization-js/pull/1796