### PR TITLE
[INFRA] Simplify surge preview teardown

### DIFF
--- a/.github/workflows/generate-site-preview.yml
+++ b/.github/workflows/generate-site-preview.yml
@@ -34,7 +34,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+        if: github.event.action != 'closed'
       - name: create .env.production file
+        if: github.event.action != 'closed'
         run: |
           touch .env.production
           echo GATSBY_GA_MEASUREMENT_ID =${{ secrets.TEST_GA_MEASUREMENT_ID }} >> .env.production


### PR DESCRIPTION
When closing the PR, the only thing to do is to run the surge teardown. So skip other actions in this case.

### Notes

This is what is done in the [playground repository](https://github.com/process-analytics/github-actions-playground/blob/5d35937bbd5ac92a0bceda3ce313c7e698d895c3/.github/workflows/surge-preview-for-pr.yml#L28)