### PR TITLE
[INFRA] Ignore `.cache` when running eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
+.cache/
 .github/
 .idea/
 /public/


### PR DESCRIPTION
It contains Gatsby generated resources.