### PR TITLE
[INFRA] Configure workflow for default read contents permissions GH TOKEN

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,10 @@ on:
       - 'package-lock.json'
       - 'gatsby-*.js'
 
+permissions:
+  # Push to gh-pages
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-20.04

--- a/.github/workflows/generate-site-preview.yml
+++ b/.github/workflows/generate-site-preview.yml
@@ -13,6 +13,10 @@ on:
       - 'package-lock.json'
       - 'gatsby-*.js'
 
+permissions:
+  # surge-preview: PR comments
+  pull-requests: write
+
 jobs:
   # inspired from https://github.com/process-analytics/github-actions-playground/pull/23
   check_secrets:


### PR DESCRIPTION
based on work done in https://github.com/process-analytics/github-actions-playground/issues/30
closes #520

**_Workflow run permissions are read-only by default_**

> GITHUB_TOKEN Permissions
  Metadata: read
  PullRequests: write