### PR TITLE
[FIX] Display the image of the 'layout generator' post

### DIFF
--- a/src/content/PostsContent.tsx
+++ b/src/content/PostsContent.tsx
@@ -29,7 +29,7 @@ const posts: PostDescription[] = [
       'Visualizing processes in BPMN standard using the BPMN layout generator', // original title which would have been truncated: 'Visualizing processes in BPMN standard: using the BPMN layout generator to show activities, transitions, and gateways'
     text: 'In this article, we will use the BPMN layout generator to automatically generate a BPMN diagram from events logs. To further help visualize the process, we will add BPMN objects such as gateways.', // abstract in Bonitasoft Community: 'In this article, we will see how you can visualize event logs with the BPMN layout generator. We will use the BPMN layout generator to automatically generate a BPMN diagram from events logs. To further help visualize the process we will add BPMN objects such as gateways.'
     cover:
-      'https://community.bonitasoft.com/sites/community.bonitasoft.com/files/blog/bonita-community/generateaprocessdiagramfromaneventlog.png',
+      'https://community.bonitasoft.com/sites/community.bonitasoft.com/files/blog/bonita-community/the_same_process_with_some_noise_filtered_out.png',
     url: 'https://community.bonitasoft.com/blog/visualizing-processes-bpmn-standard-using-bpmn-layout-generator-show-activities-transitions-and',
     date: 'December 2021',
     time: 3,

--- a/src/content/PostsContent.tsx
+++ b/src/content/PostsContent.tsx
@@ -28,7 +28,8 @@ const posts: PostDescription[] = [
     title:
       'Visualizing processes in BPMN standard using the BPMN layout generator', // original title which would have been truncated: 'Visualizing processes in BPMN standard: using the BPMN layout generator to show activities, transitions, and gateways'
     text: 'In this article, we will use the BPMN layout generator to automatically generate a BPMN diagram from events logs. To further help visualize the process, we will add BPMN objects such as gateways.', // abstract in Bonitasoft Community: 'In this article, we will see how you can visualize event logs with the BPMN layout generator. We will use the BPMN layout generator to automatically generate a BPMN diagram from events logs. To further help visualize the process we will add BPMN objects such as gateways.'
-    cover: 'https://community.bonitasoft.com/sites/community.bonitasoft.com/files/blog/bonita-community/generateaprocessdiagramfromaneventlog.png',
+    cover:
+      'https://community.bonitasoft.com/sites/community.bonitasoft.com/files/blog/bonita-community/generateaprocessdiagramfromaneventlog.png',
     url: 'https://community.bonitasoft.com/blog/visualizing-processes-bpmn-standard-using-bpmn-layout-generator-show-activities-transitions-and',
     date: 'December 2021',
     time: 3,

--- a/src/content/PostsContent.tsx
+++ b/src/content/PostsContent.tsx
@@ -28,8 +28,7 @@ const posts: PostDescription[] = [
     title:
       'Visualizing processes in BPMN standard using the BPMN layout generator', // original title which would have been truncated: 'Visualizing processes in BPMN standard: using the BPMN layout generator to show activities, transitions, and gateways'
     text: 'In this article, we will use the BPMN layout generator to automatically generate a BPMN diagram from events logs. To further help visualize the process, we will add BPMN objects such as gateways.', // abstract in Bonitasoft Community: 'In this article, we will see how you can visualize event logs with the BPMN layout generator. We will use the BPMN layout generator to automatically generate a BPMN diagram from events logs. To further help visualize the process we will add BPMN objects such as gateways.'
-    cover:
-      'https://lh5.googleusercontent.com/Kjqn5B3-PPYtJZ8k8iXtODqcIHS3AL3qlUWclH_ec-njXdCtZVnSFXz7ESRVILJCVLuXu047y_8tHxgaQ77miVPEqkoB3JIiLgpM1jqOjtQ1-8MLjGw2cfG_pFt5BaBSelY8r8GS',
+    cover: 'https://community.bonitasoft.com/sites/community.bonitasoft.com/files/blog/bonita-community/generateaprocessdiagramfromaneventlog.png',
     url: 'https://community.bonitasoft.com/blog/visualizing-processes-bpmn-standard-using-bpmn-layout-generator-show-activities-transitions-and',
     date: 'December 2021',
     time: 3,


### PR DESCRIPTION
The image was broken. The link has changed in the community.bonitasoft.com blog.

### Screenshots


before | now
----- |  -----
![image](https://user-images.githubusercontent.com/27200110/174087105-e22a3919-f29a-4b34-a18a-9883c0e885f7.png) | ![image](https://user-images.githubusercontent.com/27200110/174097914-35174b86-0181-4f7a-b812-4ddddca166fa.png)


1st proposal
![image](https://user-images.githubusercontent.com/27200110/174089533-92b1cd3e-f883-4335-bce5-4dc51e637c85.png)

