### PR TITLE
[INFRA] Improve GitHub workflow and remove duplications

### DIFF
--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -1,0 +1,14 @@
+name: 'Build Setup'
+description: 'Setup node and install dependencies'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup node
+      uses: actions/setup-node@v3
+      with:
+        node-version-file: '.nvmrc'
+    - name: Install dependencies
+      uses: bahmutov/npm-install@v1
+      with:
+        install-command: npm ci --ignore-scripts --prefer-offline --audit false --legacy-peer-deps

--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -11,4 +11,4 @@ runs:
     - name: Install dependencies
       uses: bahmutov/npm-install@v1
       with:
-        install-command: npm ci --ignore-scripts --prefer-offline --audit false --legacy-peer-deps
+        install-command: npm ci --prefer-offline --audit false --legacy-peer-deps

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -16,13 +16,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - name: Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-      - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+      - name: Build Setup
+        uses: ./.github/actions/build-setup
       - name: Lint check
         run: npm run lint-check
       - name: Check types

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,13 +22,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - name: Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-      - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+      - name: Build Setup
+        uses: ./.github/actions/build-setup
       - name: create .env.production file
         run: |
           touch .env.production

--- a/.github/workflows/generate-site-preview.yml
+++ b/.github/workflows/generate-site-preview.yml
@@ -18,34 +18,25 @@ permissions:
   pull-requests: write
 
 jobs:
-  # inspired from https://github.com/process-analytics/github-actions-playground/pull/23
-  check_secrets:
-    runs-on: ubuntu-20.04
-    outputs:
-      is_SURGE_TOKEN_set: ${{ steps.secret_availability.outputs.is_SURGE_TOKEN_set }}
-    steps:
-      - name: Compute secrets availability
-        id: secret_availability
-        env:
-          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
-        run: |
-          echo "is_SURGE_TOKEN_set: ${{ env.SURGE_TOKEN != '' }}"
-          echo "::set-output name=is_SURGE_TOKEN_set::${{ env.SURGE_TOKEN != '' }}"
-
   site_preview:
-    needs: [check_secrets]
-    if: needs.check_secrets.outputs.is_SURGE_TOKEN_set == 'true'
     runs-on: ubuntu-20.04
     steps:
+      - uses: bonitasoft/actions/packages/surge-preview-tools@v1.2.0
+        id: surge-preview-tools
+        with:
+          surge-token: ${{ secrets.SURGE_TOKEN }}
       - uses: actions/checkout@v3
         if: github.event.action != 'closed'
+      - name: Build Setup
+        if: github.event.action != 'closed'
+        uses: ./.github/actions/build-setup
       - name: create .env.production file
         if: github.event.action != 'closed'
         run: |
           touch .env.production
           echo GATSBY_GA_MEASUREMENT_ID =${{ secrets.TEST_GA_MEASUREMENT_ID }} >> .env.production
       - name: Publish Site preview
-        id: publish_site_preview
+        if: steps.surge-preview-tools.outputs.can-run-surge-command == 'true'
         uses: afc163/surge-preview@v1
         with:
           surge_token: ${{ secrets.SURGE_TOKEN }}
@@ -54,5 +45,4 @@ jobs:
           failOnError: true
           teardown: 'true'
           build: |
-            npm ci --legacy-peer-deps
             npm run build


### PR DESCRIPTION
Introduce a local action to manage the npm cache and dependencies installation. All workflows now
use it to ensure that the setup is done in same way everywhere.
The surge preview won't generate teardown errors when the domain doesn't exist. This occurred when
closing PR created by Dependabot.

closes  #546
see also https://github.com/process-analytics/bpmn-visualization-js/pull/2072