### PR TITLE
[INFRA] Update gatsby-plugin-typescript to 4.24.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "gatsby-plugin-robots-txt": "^1.7.1",
         "gatsby-plugin-sitemap": "^5.24.0",
         "gatsby-plugin-styled-components": "^5.23.0",
-        "gatsby-plugin-typescript": "^4.21.0",
+        "gatsby-plugin-typescript": "^4.24.0",
         "gatsby-remark-responsive-iframe": "~5.24.0",
         "gatsby-transformer-remark": "~5.24.0",
         "husky": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "gatsby-plugin-robots-txt": "^1.7.1",
     "gatsby-plugin-sitemap": "^5.24.0",
     "gatsby-plugin-styled-components": "^5.23.0",
-    "gatsby-plugin-typescript": "^4.21.0",
+    "gatsby-plugin-typescript": "^4.24.0",
     "gatsby-remark-responsive-iframe": "~5.24.0",
     "gatsby-transformer-remark": "~5.24.0",
     "husky": "^8.0.1",


### PR DESCRIPTION
Before to update Gastby to v5, we update all its plugins on their last v4 version.