### PR TITLE
[INFRA] Update gatsby to 4.24.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "gatsby-plugin-mdx": "^3.20.0",
         "gatsby-plugin-robots-txt": "^1.7.1",
         "gatsby-plugin-sitemap": "^5.24.0",
-        "gatsby-plugin-styled-components": "^5.23.0",
+        "gatsby-plugin-styled-components": "^5.24.0",
         "gatsby-plugin-typescript": "^4.24.0",
         "gatsby-remark-responsive-iframe": "~5.24.0",
         "gatsby-transformer-remark": "~5.24.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "eslint-plugin-mdx": "^2.0.5",
         "eslint-plugin-notice": "^0.9.10",
         "eslint-plugin-prettier": "^4.2.1",
-        "gatsby": "^4.24.7",
+        "gatsby": "^4.24.8",
         "gatsby-plugin-google-gtag": "^4.24.0",
         "gatsby-plugin-mailchimp": "^5.2.2",
         "gatsby-plugin-manifest": "^4.24.0",
@@ -11695,9 +11695,9 @@
       }
     },
     "node_modules/gatsby": {
-      "version": "4.24.7",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-4.24.7.tgz",
-      "integrity": "sha512-9eA80r0T618fdgdbNa/xuxJpsl0sPD2HBflPC18zNqhwCrboEXe057/VU2DUnQfqrgRislCAf8XDVTjgFXjbbQ==",
+      "version": "4.24.8",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-4.24.8.tgz",
+      "integrity": "sha512-dbpAXMpWPv0P3H+xYhK2+XZ+W0xsgvZUvQTYhYEro7jVh9gBJr68tlT4YYH7J+9FThrIcg6MPLN7KLVJp8yyGw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -34771,9 +34771,9 @@
       "dev": true
     },
     "gatsby": {
-      "version": "4.24.7",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-4.24.7.tgz",
-      "integrity": "sha512-9eA80r0T618fdgdbNa/xuxJpsl0sPD2HBflPC18zNqhwCrboEXe057/VU2DUnQfqrgRislCAf8XDVTjgFXjbbQ==",
+      "version": "4.24.8",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-4.24.8.tgz",
+      "integrity": "sha512-dbpAXMpWPv0P3H+xYhK2+XZ+W0xsgvZUvQTYhYEro7jVh9gBJr68tlT4YYH7J+9FThrIcg6MPLN7KLVJp8yyGw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.14.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "eslint-plugin-notice": "^0.9.10",
         "eslint-plugin-prettier": "^4.2.1",
         "gatsby": "^4.24.7",
-        "gatsby-plugin-google-gtag": "^4.21.0",
+        "gatsby-plugin-google-gtag": "^4.24.0",
         "gatsby-plugin-mailchimp": "^5.2.2",
         "gatsby-plugin-manifest": "^4.24.0",
         "gatsby-plugin-material-ui": "^4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "gatsby-plugin-robots-txt": "^1.7.1",
         "gatsby-plugin-sitemap": "^5.24.0",
         "gatsby-plugin-styled-components": "^5.23.0",
-        "gatsby-plugin-typescript": "^4.21.0",
+        "gatsby-plugin-typescript": "^4.24.0",
         "gatsby-remark-responsive-iframe": "~5.24.0",
         "gatsby-transformer-remark": "~5.24.0",
         "husky": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "gatsby-plugin-robots-txt": "^1.7.1",
     "gatsby-plugin-sitemap": "^5.24.0",
     "gatsby-plugin-styled-components": "^5.23.0",
-    "gatsby-plugin-typescript": "^4.21.0",
+    "gatsby-plugin-typescript": "^4.24.0",
     "gatsby-remark-responsive-iframe": "~5.24.0",
     "gatsby-transformer-remark": "~5.24.0",
     "husky": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "eslint-plugin-mdx": "^2.0.5",
     "eslint-plugin-notice": "^0.9.10",
     "eslint-plugin-prettier": "^4.2.1",
-    "gatsby": "^4.24.7",
+    "gatsby": "^4.24.8",
     "gatsby-plugin-google-gtag": "^4.24.0",
     "gatsby-plugin-mailchimp": "^5.2.2",
     "gatsby-plugin-manifest": "^4.24.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-notice": "^0.9.10",
     "eslint-plugin-prettier": "^4.2.1",
     "gatsby": "^4.24.7",
-    "gatsby-plugin-google-gtag": "^4.21.0",
+    "gatsby-plugin-google-gtag": "^4.24.0",
     "gatsby-plugin-mailchimp": "^5.2.2",
     "gatsby-plugin-manifest": "^4.24.0",
     "gatsby-plugin-material-ui": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "gatsby-plugin-mdx": "^3.20.0",
     "gatsby-plugin-robots-txt": "^1.7.1",
     "gatsby-plugin-sitemap": "^5.24.0",
-    "gatsby-plugin-styled-components": "^5.23.0",
+    "gatsby-plugin-styled-components": "^5.24.0",
     "gatsby-plugin-typescript": "^4.24.0",
     "gatsby-remark-responsive-iframe": "~5.24.0",
     "gatsby-transformer-remark": "~5.24.0",


### PR DESCRIPTION
Before to update Gastby to v5, we update all its plugins and itself on their last v4 version.

- gatsby to 4.24.8
- gatsby-plugin-google-gtag to 4.24.0
- gatsby-plugin-styled-components to 5.24.0
- gatsby-plugin-typescript to 4.24.0