### PR TITLE
refactor: rename section components

### DIFF
--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -24,7 +24,7 @@ import { DataProps } from '../hooks/use-site-metadata';
 import { footerRoutes } from '../content/FooterRoutes';
 import { Footer } from '../theme/components/Footer';
 import Layout from '../theme/components/Layout';
-import Section from '../theme/components/Section';
+import { Section } from '../theme/components/Section';
 import Triangle from '../theme/components/Triangle';
 import { PAGE } from '../theme/utils/constants';
 import PageHeader from '../theme/components/PageHeader';
@@ -45,7 +45,7 @@ const StyledParagraph = styled.p`
 const NotFoundPage = (): JSX.Element => (
   <Layout>
     <PageHeader />
-    <Section.Container Background={Background}>
+    <Section Background={Background}>
       <h1 style={{ textAlign: 'center' }}>
         <Image
           src={Img}
@@ -65,7 +65,7 @@ const NotFoundPage = (): JSX.Element => (
           <Link to="/">HOME PAGE</Link>
         </strong>
       </StyledParagraph>
-    </Section.Container>
+    </Section>
     {/* TODO: When there will only one theme provider, move the Footer in the
     Layout class */}
     <Footer content={footerRoutes} />

--- a/src/pages/model-generation-application-conditions.tsx
+++ b/src/pages/model-generation-application-conditions.tsx
@@ -25,7 +25,7 @@ import { Part, Paragraph, PartTitle } from './model-generation-application';
 
 import { footerRoutes } from '../content/FooterRoutes';
 import { Footer } from '../theme/components/Footer';
-import Section from '../theme/components/Section';
+import { Section } from '../theme/components/Section';
 import Triangle from '../theme/components/Triangle';
 import PageHeader from '../theme/components/PageHeader';
 import Layout from '../theme/components/Layout';
@@ -37,7 +37,7 @@ const ModelGenerationApplicationConditionPage = (): JSX.Element => {
   return (
     <Layout>
       <PageHeader displayDemoButton={false} />
-      <Section.Container Background={Background}>
+      <Section Background={Background}>
         <Heading
           textAlign="center"
           as="h1"
@@ -158,7 +158,7 @@ const ModelGenerationApplicationConditionPage = (): JSX.Element => {
             INCLUDING NEGLIGENCE.
           </Paragraph>
         </Part>
-      </Section.Container>
+      </Section>
       {/* TODO: When there will only one theme provider, move the Footer in the
     Layout class */}
       <Footer content={footerRoutes} />

--- a/src/pages/model-generation-application.tsx
+++ b/src/pages/model-generation-application.tsx
@@ -37,7 +37,7 @@ import { postsContent } from '../content/PostsContent';
 import { footerRoutes } from '../content/FooterRoutes';
 import { Footer } from '../theme/components/Footer';
 import { PostDescription } from '../theme/types';
-import Section from '../theme/components/Section';
+import { Section } from '../theme/components/Section';
 import Triangle from '../theme/components/Triangle';
 import PageHeader from '../theme/components/PageHeader';
 import Layout from '../theme/components/Layout';
@@ -180,7 +180,7 @@ const ModelGenerationApplicationPage = (): JSX.Element => {
   return (
     <Layout>
       <PageHeader displayDemoButton={false} />
-      <Section.Container Background={Background}>
+      <Section Background={Background}>
         <Heading
           textAlign="center"
           as="h1"
@@ -190,8 +190,8 @@ const ModelGenerationApplicationPage = (): JSX.Element => {
         >
           Model Generation Application
         </Heading>
-      </Section.Container>
-      <Section.Container minHeight="auto">
+      </Section>
+      <Section minHeight="auto">
         <Box
           style={{
             boxShadow:
@@ -205,8 +205,8 @@ const ModelGenerationApplicationPage = (): JSX.Element => {
             alt={'Model Generation Application Demo'}
           />
         </Box>
-      </Section.Container>
-      <Section.Container>
+      </Section>
+      <Section>
         <PartWithSingleColumn>
           <PartTitle>
             Need a tool to generate process diagrams from events logs?
@@ -214,8 +214,8 @@ const ModelGenerationApplicationPage = (): JSX.Element => {
           <HighlightMessage>We have a solution for you!</HighlightMessage>
           <Features />
         </PartWithSingleColumn>
-      </Section.Container>
-      <Section.Container>
+      </Section>
+      <Section>
         <PartWithSingleColumn backgroundColor="muted">
           <PartTitle marginBottom="52px">How it works?</PartTitle>
           <Part
@@ -249,8 +249,8 @@ const ModelGenerationApplicationPage = (): JSX.Element => {
             </Paragraph>
           </Part>
         </PartWithSingleColumn>
-      </Section.Container>
-      <Section.Container>
+      </Section>
+      <Section>
         <Part
           justifyContent="space-between"
           alignItems="center"
@@ -293,8 +293,8 @@ const ModelGenerationApplicationPage = (): JSX.Element => {
             ready.
           </Paragraph>
         </Part>
-      </Section.Container>
-      <Section.Container>
+      </Section>
+      <Section>
         <Part
           id={'form'}
           marginBottom="124px"
@@ -310,8 +310,8 @@ const ModelGenerationApplicationPage = (): JSX.Element => {
         >
           <Jotform />
         </Part>
-      </Section.Container>
-      <Section.Container>
+      </Section>
+      <Section>
         <Part
           marginBottom="52px"
           maxWidth="1320px"
@@ -328,7 +328,7 @@ const ModelGenerationApplicationPage = (): JSX.Element => {
             pageId="blog"
           />
         </Part>
-      </Section.Container>
+      </Section>
       {/* TODO: When there will only one theme provider, move the Footer in the
     Layout class */}
       <Footer content={footerRoutes} />

--- a/src/theme/components/Section.tsx
+++ b/src/theme/components/Section.tsx
@@ -22,7 +22,7 @@ import { Link } from 'gatsby';
 import { MEDIA_QUERY_SMALL, SECTION } from '../utils/constants';
 import { getSectionHref } from '../utils/helpers';
 
-type ContainerProps = {
+type SectionProps = {
   id?: SECTION;
   children: ReactNode;
   Background?: () => JSX.Element;
@@ -30,28 +30,47 @@ type ContainerProps = {
   minHeight?: string;
 };
 
-const Container = ({
+export const Section = ({
   id,
   children,
   Background = DefaultBackground,
   justifyContent = 'center',
   minHeight,
-}: ContainerProps): JSX.Element => (
-  <section id={id && getSectionHref(id)} style={{ position: 'relative' }}>
+}: SectionProps): JSX.Element => (
+  <StyledSection id={id && getSectionHref(id)}>
     <Background />
     <SectionContainer justifyContent={justifyContent} minHeight={minHeight}>
       {children}
     </SectionContainer>
-  </section>
+  </StyledSection>
 );
 
-type HeaderProps = {
+export const SectionWithTitle = ({
+  id,
+  children,
+  ...rest
+}: SectionProps & Required<Pick<SectionProps, 'id'>>): JSX.Element => (
+  <Section id={id} {...rest}>
+    <SectionHeader name={id} />
+    {children}
+  </Section>
+);
+
+const StyledSection = styled.section`
+  position: relative;
+`;
+
+type SectionHeaderProps = {
   name: SECTION;
   icon?: string;
   label?: string;
 };
 
-const Header = ({ name, icon, label }: HeaderProps): JSX.Element => (
+const SectionHeader = ({
+  name,
+  icon,
+  label,
+}: SectionHeaderProps): JSX.Element => (
   <Slide direction="left" triggerOnce>
     <Heading color="text" mb={4}>
       <Link
@@ -92,8 +111,3 @@ const SectionContainer = styled.div<SectionContainerProps>`
 `;
 
 const DefaultBackground = (): JSX.Element => <div />;
-
-export default {
-  Container,
-  Header,
-};

--- a/src/theme/pages/PageWithPosts.tsx
+++ b/src/theme/pages/PageWithPosts.tsx
@@ -20,7 +20,7 @@ import { footerRoutes } from '../../content/FooterRoutes';
 import { Footer } from '../components/Footer';
 import Layout from '../components/Layout';
 import PageHeader from '../components/PageHeader';
-import Section from '../components/Section';
+import { Section } from '../components/Section';
 import { Heading, Text } from 'rebass/styled-components';
 import Triangle from '../components/Triangle';
 import { PostContainer } from '../components/Post';
@@ -46,7 +46,7 @@ export const PageWithPosts = ({
 }: PageWithPostsProps): JSX.Element => (
   <Layout>
     <PageHeader />
-    <Section.Container id={containerTitle} Background={Background}>
+    <Section id={containerTitle} Background={Background}>
       <Heading
         textAlign="center"
         as="h1"
@@ -69,7 +69,7 @@ export const PageWithPosts = ({
         {description}
       </Text>
       <PostContainer posts={posts} />
-    </Section.Container>
+    </Section>
     <MailingListSubscription />
     {/* TODO: When there will only one theme provider, move the Footer in the
     Layout class */}

--- a/src/theme/sections/About.tsx
+++ b/src/theme/sections/About.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import React from 'react';
-import Section from '../components/Section';
+import { SectionWithTitle } from '../components/Section';
 import Triangle from '../components/Triangle';
 import { SECTION } from '../utils/constants';
 import { about } from '../../content/AboutContent';
@@ -22,13 +22,11 @@ import DescriptionPanel from '../components/description/DescriptionPanel';
 
 const About = (): JSX.Element => {
   return (
-    <Section.Container id={SECTION.about} Background={Background}>
-      <Section.Header name={SECTION.about} />
-
+    <SectionWithTitle id={SECTION.about} Background={Background}>
       {about.map((subsection, index) => (
         <DescriptionPanel key={index} index={index} {...subsection} />
       ))}
-    </Section.Container>
+    </SectionWithTitle>
   );
 };
 

--- a/src/theme/sections/Blog.tsx
+++ b/src/theme/sections/Blog.tsx
@@ -21,7 +21,7 @@ import { SectionWithPosts } from './SectionWithPosts';
 
 const Blog = (): JSX.Element => (
   <SectionWithPosts
-    containerTitle={SECTION.blog}
+    title={SECTION.blog}
     Background={Background}
     posts={postsContent.posts}
     pageId="blog"

--- a/src/theme/sections/Landing.tsx
+++ b/src/theme/sections/Landing.tsx
@@ -17,7 +17,7 @@ import { Link } from 'gatsby';
 import React from 'react';
 import { Heading, Flex, Box, Text, Button } from 'rebass/styled-components';
 import styled from 'styled-components';
-import Section from '../components/Section';
+import { Section } from '../components/Section';
 import { SocialLink } from '../components/SocialLink';
 import Triangle from '../components/Triangle';
 import { SECTION } from '../utils/constants';
@@ -27,13 +27,13 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 const centerHorizontally = { marginRight: 'auto', marginLeft: 'auto' };
 
-const LandingPage = (): JSX.Element => {
+const Landing = (): JSX.Element => {
   const { title, presentation, socialLinks } = {
     ...landing,
   };
 
   return (
-    <Section.Container
+    <Section
       id={SECTION.home}
       Background={Background}
       justifyContent="space-around"
@@ -125,7 +125,7 @@ const LandingPage = (): JSX.Element => {
           </Button>
         </Flex>
       </LandingCard>
-    </Section.Container>
+    </Section>
   );
 };
 
@@ -164,4 +164,4 @@ const LandingCard = styled(Box).attrs({
   align-self: center;
 `;
 
-export default LandingPage;
+export default Landing;

--- a/src/theme/sections/Libraries.tsx
+++ b/src/theme/sections/Libraries.tsx
@@ -15,7 +15,7 @@
  */
 import React from 'react';
 import { Fade } from 'react-awesome-reveal';
-import Section from '../components/Section';
+import { SectionWithTitle } from '../components/Section';
 import { CardContainer } from '../components/Card';
 import Triangle from '../components/Triangle';
 import Library from '../components/Library';
@@ -26,9 +26,7 @@ const cardMinWidth = '300px';
 
 const Libraries = (): JSX.Element => {
   return (
-    <Section.Container id={SECTION.libraries} Background={Background}>
-      <Section.Header name={SECTION.libraries} />
-
+    <SectionWithTitle id={SECTION.libraries} Background={Background}>
       <CardContainer minWidth={cardMinWidth}>
         <Fade direction="down" cascade damping={0.5} triggerOnce>
           {libraries.map((p, i) => (
@@ -36,7 +34,7 @@ const Libraries = (): JSX.Element => {
           ))}
         </Fade>
       </CardContainer>
-    </Section.Container>
+    </SectionWithTitle>
   );
 };
 

--- a/src/theme/sections/News.tsx
+++ b/src/theme/sections/News.tsx
@@ -21,7 +21,7 @@ import { SectionWithPosts } from './SectionWithPosts';
 
 const News = (): JSX.Element => (
   <SectionWithPosts
-    containerTitle={SECTION.news}
+    title={SECTION.news}
     Background={Background}
     posts={newsContent.news}
     pageId="news"

--- a/src/theme/sections/SectionWithPosts.tsx
+++ b/src/theme/sections/SectionWithPosts.tsx
@@ -14,26 +14,25 @@
  * limitations under the License.
  */
 import React from 'react';
-import Section from '../components/Section';
+import { SectionWithTitle } from '../components/Section';
 import { SECTION } from '../utils/constants';
 import { PostContainer } from '../components/Post';
 import { PostDescription } from '../types';
 
 interface SectionWithPostsProps {
-  containerTitle: SECTION;
+  title: SECTION;
   Background?: () => JSX.Element;
   posts: PostDescription[];
   pageId: string;
 }
 
 export const SectionWithPosts = ({
-  containerTitle,
+  title,
   Background,
   posts,
   pageId,
 }: SectionWithPostsProps): JSX.Element => (
-  <Section.Container id={containerTitle} Background={Background}>
-    <Section.Header name={containerTitle} />
+  <SectionWithTitle id={title} Background={Background}>
     <PostContainer posts={posts} pageId={pageId} />
-  </Section.Container>
+  </SectionWithTitle>
 );


### PR DESCRIPTION
*   Rename `Section.Container` in `Section`
*   Rename `Section.Header` in `SectionHeader`
*   Export `Section`  and `SectionHeader` not as `default`
*   Introduce `SectionWithTitle` component
*   Rename `containerTitle` attribute in `SectionWithPosts` to `title`