### PR TITLE
feat: change the order of the sections in the header

### DIFF
--- a/src/theme/utils/constants.ts
+++ b/src/theme/utils/constants.ts
@@ -19,11 +19,11 @@ export const GATSBY_URL = 'https://www.gatsbyjs.org/';
 // values are used as section title
 export enum SECTION {
   home = 'Home',
+  modelGenerationApp = 'Model Generation Application',
   about = 'About',
   libraries = 'Libraries',
   news = 'News',
   blog = 'Blog Posts',
-  modelGenerationApp = 'Model Generation Application',
 }
 
 /**

--- a/src/theme/utils/string.ts
+++ b/src/theme/utils/string.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 export const capitalize = (s: string): string =>
-  s[0].toUpperCase() + s.slice(1);
+  (s[0].toUpperCase() + s.slice(1)).split(/(?=[A-Z])/).join(' ');


### PR DESCRIPTION
To be in the same order as in the `home` page.

| Before | Now |  
| ------- | ----- |  
| ![image](https://user-images.githubusercontent.com/4921914/220140431-5dce5ed1-6880-4611-84ad-728d2a41fc12.png) | ![image](https://user-images.githubusercontent.com/4921914/220140358-5894d4c7-d152-4acf-a67d-6edddcc37892.png) |