### PR TITLE
feat(mobile): change the section background on mobile format

### DIFF
--- a/src/theme/components/Section.tsx
+++ b/src/theme/components/Section.tsx
@@ -63,19 +63,32 @@ type StyledSectionProps = {
 const StyledSection = styled.section<StyledSectionProps>`
   position: relative;
   display: block;
+
+  border-radius: 0px;
+
+  @media only screen and (min-width: 61.188rem) {
+    &:nth-of-type(even):not(:last-of-type) {
+      border-top-left-radius: 18.75rem;
+      border-bottom-left-radius: 18.75rem;
+    }
+
+    &:nth-of-type(odd):not(:first-of-type) {
+      border-bottom-right-radius: 18.75rem;
+      border-top-right-radius: 18.75rem;
+    }
+  }
+
   text {
-    padding: 45px 0;
+    padding: 2.813rem 0;
   }
+
   &:first-of-type {
-    margin-top: 101px;
+    margin-top: 6.25rem;
   }
+
   &:nth-of-type(even) {
     position: relative;
     background-color: ${({ backgroundColor }) => backgroundColor};
-  }
-  &:nth-of-type(even):not(:last-of-type) {
-    border-top-left-radius: 300px;
-    border-bottom-left-radius: 300px;
   }
   &:nth-of-type(even) > ::before {
     background-color: white;
@@ -86,13 +99,10 @@ const StyledSection = styled.section<StyledSectionProps>`
     height: 100%;
     z-index: -1;
   }
+
   &:nth-of-type(odd) {
     position: relative;
     background-color: white;
-  }
-  &:nth-of-type(odd):not(:first-of-type) {
-    border-bottom-right-radius: 300px;
-    border-top-right-radius: 300px;
   }
   &:nth-of-type(odd) > ::before {
     background-color: ${({ backgroundColor }) => backgroundColor};


### PR DESCRIPTION
<table><tbody><tr><td>Before</td><td>Now</td></tr><tr><td><figure class="image"><img src="https://user-images.githubusercontent.com/4921914/222773459-6a6f789e-8756-46cb-8c2d-cb9e4ffa08ae.png"></figure></td><td><figure class="image"><img src="https://user-images.githubusercontent.com/4921914/222773404-13bba0c2-ad17-4420-a31d-064fd9e030d3.png"></figure></td></tr></tbody></table>