### PR TITLE
fix: fix the size of the bottom space of the `Librairies` section

### DIFF
--- a/src/theme/components/Card.tsx
+++ b/src/theme/components/Card.tsx
@@ -18,10 +18,13 @@ import { Card as CardRebass } from 'rebass/styled-components';
 
 type CardContainerProps = {
   minWidth: string;
+  mb?: string;
 };
 
 export const CardContainer = styled.div<CardContainerProps>`
   display: grid;
+  margin-bottom: ${({ mb }) => mb};
+
   grid-gap: 30px;
 
   grid-template-columns: repeat(

--- a/src/theme/components/Layout.tsx
+++ b/src/theme/components/Layout.tsx
@@ -68,13 +68,6 @@ const GlobalStyle = createGlobalStyle`
     line-height: 1.5;
   }
 
-  a[href]{
-    cursor: pointer;
-  }
-  a {
-    text-decoration: none;
-    background-color: transparent;
-  }
   h1 {
     font-size: 3rem;
     font-weight: bold;

--- a/src/theme/sections/Libraries.tsx
+++ b/src/theme/sections/Libraries.tsx
@@ -28,7 +28,7 @@ const cardMinWidth = '300px';
 export const Libraries = (): JSX.Element => {
   return (
     <SectionWithTitle id={SECTION.libraries}>
-      <CardContainer minWidth={cardMinWidth}>
+      <CardContainer minWidth={cardMinWidth} mb="30px">
         <Fade direction="down" cascade damping={0.5} triggerOnce>
           {libraries.map((p, i) => (
             <Library {...p} key={i} />


### PR DESCRIPTION
<table><tbody><tr><td>Before</td><td>Now</td></tr><tr><td><figure class="image"><img src="https://user-images.githubusercontent.com/4921914/222780454-82ce9ef8-2491-46ed-8a9c-3f6215ae2e39.png"></figure></td><td><figure class="image"><img src="https://user-images.githubusercontent.com/4921914/222780521-f6852ec2-2085-4176-acbc-71345288e7fa.png"></figure></td></tr></tbody></table>