### PR TITLE
feat: improve the design of the mobile view

### DIFF
--- a/src/pages/model-generation-application.tsx
+++ b/src/pages/model-generation-application.tsx
@@ -222,18 +222,20 @@ const ModelGenerationApplicationPage = (): JSX.Element => {
       </Section>
       <Section>
         <PartWithSingleColumn backgroundColor="muted">
-          <PartTitle marginBottom="52px">How it works?</PartTitle>
+          <PartTitle marginBottom="3.25rem">How it works?</PartTitle>
           <Part
             marginTop="24px"
             justifyContent={'space-around'}
             alignItems={'center'}
+            flexDirection={['column', 'row']}
           >
             <Image
               src={HowItWorksImg}
               alt={'Generation Model Application Demo'}
-              width="45%"
+              width={['100%', '45%']}
+              marginBottom={['3.25rem', 0]}
             />
-            <Paragraph width="40%" fontSize={[1, 1, 2, 3]}>
+            <Paragraph width={['100%', '40%']} fontSize={[1, 1, 2, 3]}>
               The Model Generation Application is a{' '}
               <Link href="https://shiny.rstudio.com/">shiny R application</Link>{' '}
               that takes an event log file in{' '}
@@ -257,16 +259,18 @@ const ModelGenerationApplicationPage = (): JSX.Element => {
       </Section>
       <Section>
         <Part
+          flexDirection={['column', 'row']}
           justifyContent="space-between"
           alignItems="center"
           padding="114px 24px"
-          width="80%"
+          width={['100%', '80%']}
           marginX="auto"
         >
           <Flex
             width={['5rem', '5.5rem', '6.875rem']}
             height={['5rem', '5.5rem', '6.875rem']}
             alignItems="center"
+            marginBottom={['3.25rem', 0]}
             style={{
               borderRadius: '0.75rem',
               borderColor: colors.primary,

--- a/src/sections/home/ModelGenerationApp.tsx
+++ b/src/sections/home/ModelGenerationApp.tsx
@@ -34,15 +34,25 @@ const Container = styled(Flex)`
   margin: 30px auto;
   display: inline-flex;
   flex-wrap: wrap;
+  flex-direction: column-reverse;
+  align-items: center;
   justify-content: center;
   max-width: 100rem;
+
+  @media only screen and (min-width: 61.188rem) {
+    flex-direction: row;
+  }
 `;
 
 const Title = styled.h2`
   position: relative;
   color: ${props => props.theme.colors.primary};
   font-weight: bold;
-  font-size: 30px;
+  font-size: 1.625rem;
+
+  @media only screen and (min-width: 61.188rem) {
+    font-size: 1.875rem;
+  }
 `;
 
 const Description = styled.div`
@@ -61,8 +71,9 @@ export const ModelGenerationApp = (): JSX.Element => {
         <Flex
           flexDirection="column"
           justifyContent="center"
+          alignItems={['center', 'start']}
           paddingX={[2, 3, '4.25rem']}
-          maxWidth="50%"
+          maxWidth={['100%', '50%']}
         >
           <Title>
             Need a tool to generate process diagrams from events logs?
@@ -90,7 +101,7 @@ export const ModelGenerationApp = (): JSX.Element => {
           flexDirection="column"
           justifyContent="center"
           paddingX={[2, 3, '4.25rem']}
-          width="30%"
+          width={['80%', '30%']}
         >
           <FontAwesomeIcon
             icon="database"

--- a/src/theme/components/Post.tsx
+++ b/src/theme/components/Post.tsx
@@ -24,6 +24,7 @@ import { PostDescription } from '../types';
 import { Card, CardContainer, CardFooter, ButtonWithInternalLink } from '.';
 
 import colors from '../colors.json';
+import { isMobileView } from '../utils/helpers';
 
 const cardMinWidth = '350px';
 
@@ -86,16 +87,17 @@ export const PostContainer = ({
   posts,
   pageId,
 }: PostContainerProps): JSX.Element => {
+  const maxNumberOfPosts = isMobileView() ? 3 : 8;
   return (
     <>
       <CardContainer minWidth={cardMinWidth}>
         <DownFade>
-          {(pageId ? posts.slice(0, 8) : posts).map(p => (
+          {(pageId ? posts.slice(0, maxNumberOfPosts) : posts).map(p => (
             <Post {...p} key={p.url} />
           ))}
         </DownFade>
       </CardContainer>
-      {pageId && posts.length > 8 && (
+      {pageId && posts.length > maxNumberOfPosts && (
         <DownFade>
           <Flex justifyContent="center" mt="30px" mb="30px" fontSize={[2, 3]}>
             <ButtonWithInternalLink

--- a/src/theme/components/Post.tsx
+++ b/src/theme/components/Post.tsx
@@ -49,7 +49,7 @@ export const Post = ({
         {title}
       </EllipsisHeading>
       {cover && <CoverImage src={cover} alt={title} />}
-      <Text m={3} color="text">
+      <Text m={3} color="text" fontSize={['0.875rem', '1.25rem']}>
         {text}
       </Text>
       <CardFooter bg="primary" color="background" position="bottom-right" round>

--- a/src/theme/components/Post.tsx
+++ b/src/theme/components/Post.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { ReactNode, useEffect } from 'react';
+import React, { ReactNode } from 'react';
 
 import { Flex, Heading, Text } from 'rebass/styled-components';
 import styled from 'styled-components';

--- a/src/theme/components/Post.tsx
+++ b/src/theme/components/Post.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useEffect } from 'react';
 
 import { Flex, Heading, Text } from 'rebass/styled-components';
 import styled from 'styled-components';
@@ -49,7 +49,7 @@ export const Post = ({
         {title}
       </EllipsisHeading>
       {cover && <CoverImage src={cover} alt={title} />}
-      <Text m={3} color="text" fontSize={['0.875rem', '1.25rem']}>
+      <Text m={3} color="text" fontSize={['0.875rem', '1rem']}>
         {text}
       </Text>
       <CardFooter bg="primary" color="background" position="bottom-right" round>
@@ -87,7 +87,7 @@ export const PostContainer = ({
   posts,
   pageId,
 }: PostContainerProps): JSX.Element => {
-  const maxNumberOfPosts = isMobileView() ? 3 : 8;
+  const maxNumberOfPosts = isMobileView() ? 3 : 6;
   return (
     <>
       <CardContainer minWidth={cardMinWidth}>

--- a/src/theme/components/Section.tsx
+++ b/src/theme/components/Section.tsx
@@ -67,6 +67,10 @@ const StyledSection = styled.section<StyledSectionProps>`
   border-radius: 0px;
 
   @media only screen and (min-width: 61.188rem) {
+    &:first-of-type {
+      margin-top: 6.25rem;
+    }
+
     &:nth-of-type(even):not(:last-of-type) {
       border-top-left-radius: 18.75rem;
       border-bottom-left-radius: 18.75rem;
@@ -80,10 +84,6 @@ const StyledSection = styled.section<StyledSectionProps>`
 
   text {
     padding: 2.813rem 0;
-  }
-
-  &:first-of-type {
-    margin-top: 6.25rem;
   }
 
   &:nth-of-type(even) {

--- a/src/theme/components/Section.tsx
+++ b/src/theme/components/Section.tsx
@@ -147,7 +147,7 @@ const SectionHeader = ({
   <Heading
     color="text"
     fontWeight="700"
-    fontSize="30px"
+    fontSize="1.875rem"
     margin="30px 65px"
     textAlign="center"
   >

--- a/src/theme/components/material-kit/Navbar/Navbar.tsx
+++ b/src/theme/components/material-kit/Navbar/Navbar.tsx
@@ -46,7 +46,10 @@ import { Action, ActionButton, BrandLink, NavbarItems } from './common';
 import { NavbarButton, NavbarNav } from './mobile';
 import { Dropdown } from './desktop';
 
-import { isMobileView as isMobileViewFunc } from '../../../utils/helpers';
+import {
+  isMobileView,
+  isMobileView as isMobileViewFunc,
+} from '../../../utils/helpers';
 
 const InnerContainer = ({
   brand,
@@ -64,16 +67,14 @@ const InnerContainer = ({
   const [collapseName, setCollapseName] = useState<string>();
 
   const [isOpenMobileNavbar, setIsOpenMobileNavbar] = useState(false);
-  const [isMobileView, setIsMobileView] = useState(false);
+  const isMobileView = isMobileViewFunc();
 
   useEffect(() => {
     // A function that sets the display state for NavbarMobile.
     function displayMobileNavbar(): void {
-      if (isMobileViewFunc()) {
-        setIsMobileView(true);
+      if (isMobileView) {
         setIsOpenMobileNavbar(false);
       } else {
-        setIsMobileView(false);
         setIsOpenMobileNavbar(false);
       }
     }

--- a/src/theme/components/material-kit/Navbar/Navbar.tsx
+++ b/src/theme/components/material-kit/Navbar/Navbar.tsx
@@ -46,10 +46,7 @@ import { Action, ActionButton, BrandLink, NavbarItems } from './common';
 import { NavbarButton, NavbarNav } from './mobile';
 import { Dropdown } from './desktop';
 
-import {
-  isMobileView,
-  isMobileView as isMobileViewFunc,
-} from '../../../utils/helpers';
+import { isMobileView as isMobileViewFunc } from '../../../utils/helpers';
 
 const InnerContainer = ({
   brand,

--- a/src/theme/components/material-kit/Navbar/Navbar.tsx
+++ b/src/theme/components/material-kit/Navbar/Navbar.tsx
@@ -38,14 +38,15 @@ import { Container } from '@mui/material';
 import { MKBox, MKBoxProps } from '..';
 
 // Material Kit 2 React base styles
-import { breakpoints } from '../../../../assets/theme/base';
-import { pxToRem } from '../../../../assets/theme/functions';
+
 import { HeaderRoute } from '../../../types';
 
 // Material Kit 2 React example components
 import { Action, ActionButton, BrandLink, NavbarItems } from './common';
 import { NavbarButton, NavbarNav } from './mobile';
 import { Dropdown } from './desktop';
+
+import { isMobileView as isMobileViewFunc } from '../../../utils/helpers';
 
 const InnerContainer = ({
   brand,
@@ -68,11 +69,7 @@ const InnerContainer = ({
   useEffect(() => {
     // A function that sets the display state for NavbarMobile.
     function displayMobileNavbar(): void {
-      // TODO Clean
-      if (
-        Number(pxToRem(window.innerWidth).replace('rem', '')) <
-        breakpoints.values.lg
-      ) {
+      if (isMobileViewFunc()) {
         setIsMobileView(true);
         setIsOpenMobileNavbar(false);
       } else {

--- a/src/theme/components/material-kit/Navbar/common/NavbarItem.tsx
+++ b/src/theme/components/material-kit/Navbar/common/NavbarItem.tsx
@@ -46,7 +46,7 @@ const TitleContainer = ({
     display="flex"
     alignItems="baseline"
     //opacity={isMobileView && open ? 1 : 0.6}
-    sx={({ palette: { grey, spicy } }: Theme) => ({
+    sx={({ palette: { quaternary, spicy } }: Theme) => ({
       cursor: 'pointer',
       userSelect: 'none',
       transition: 'all 300ms linear',
@@ -59,17 +59,19 @@ const TitleContainer = ({
         },
       }),
 
-      ...(isMobileView && {
-        // TODO Make configurable color
-        '&:hover': {
-          backgroundColor: !isCollapsible && grey[200],
-          color: !isCollapsible && grey?.A700,
+      ...(isMobileView &&
+        !isCollapsible && {
+          // TODO Make configurable color
+          '&:hover': {
+            backgroundColor: quaternary.main,
+            color: spicy.main,
+            borderRadius: '5px',
 
-          '& *': {
-            color: !isCollapsible && grey?.A700,
+            '& *': {
+              color: spicy.main,
+            },
           },
-        },
-      }),
+        }),
     })}
   >
     {children}

--- a/src/theme/components/material-kit/Navbar/mobile/DropdownDropdown.tsx
+++ b/src/theme/components/material-kit/Navbar/mobile/DropdownDropdown.tsx
@@ -60,15 +60,19 @@ export const DropdownDropdown = ({
         fontWeight="regular"
         py={0.625}
         px={2}
-        sx={({ palette: { grey }, borders: { borderRadius } }: Theme) => ({
+        sx={({
+          palette: { quaternary, spicy },
+          borders: { borderRadius },
+        }: Theme) => ({
           borderRadius: borderRadius.md,
           cursor: 'pointer',
           transition: 'all 300ms linear',
 
           // TODO Make configurable color
           '&:hover': {
-            backgroundColor: grey[200],
-            color: grey?.A700,
+            backgroundColor: quaternary.main,
+            color: spicy.main,
+            borderRadius: '5px',
           },
         })}
       >

--- a/src/theme/components/material-kit/Navbar/mobile/DropdownLink.tsx
+++ b/src/theme/components/material-kit/Navbar/mobile/DropdownLink.tsx
@@ -46,7 +46,10 @@ export const DropdownLink = ({
     key={`${name}_${id}`}
     display="block"
     {...getLinkAttributes({ type, url })}
-    sx={({ palette: { grey }, borders: { borderRadius } }: Theme) => ({
+    sx={({
+      palette: { quaternary, spicy },
+      borders: { borderRadius },
+    }: Theme) => ({
       borderRadius: borderRadius.md,
       cursor: 'pointer',
       transition: 'all 300ms linear',
@@ -55,11 +58,12 @@ export const DropdownLink = ({
 
       // TODO Make configurable color
       '&:hover': {
-        backgroundColor: grey[200],
-        color: grey?.A700,
+        backgroundColor: quaternary.main,
+        color: spicy.main,
+        borderRadius: '5px',
 
         '& *': {
-          color: grey?.A700,
+          color: spicy.main,
         },
       },
     })}

--- a/src/theme/utils/helpers.ts
+++ b/src/theme/utils/helpers.ts
@@ -24,11 +24,11 @@ export const getSectionHref = (section: SECTION): string => {
   return Object.keys(SECTION)[Object.values(SECTION).indexOf(section)];
 };
 
-export const isMobileView = () => {
+export const isMobileView = (): boolean => {
   const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
-    const handleResize = () => {
+    const handleResize = (): void => {
       // TODO Clean
       setIsMobile(
         Number(pxToRem(window.innerWidth).replace('rem', '')) <

--- a/src/theme/utils/helpers.ts
+++ b/src/theme/utils/helpers.ts
@@ -13,14 +13,37 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { useEffect, useState } from 'react';
+
 import { SECTION } from './constants';
 
 import { breakpoints } from '../../assets/theme/base';
 import { pxToRem } from '../../assets/theme/functions';
+
 export const getSectionHref = (section: SECTION): string => {
   return Object.keys(SECTION)[Object.values(SECTION).indexOf(section)];
 };
 
-export const isMobileView = (): boolean =>
-  // TODO Clean
-  Number(pxToRem(window.innerWidth).replace('rem', '')) < breakpoints.values.lg;
+export const isMobileView = () => {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const handleResize = () => {
+      // TODO Clean
+      setIsMobile(
+        Number(pxToRem(window.innerWidth).replace('rem', '')) <
+          breakpoints.values.lg,
+      );
+    };
+
+    handleResize();
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return isMobile;
+};

--- a/src/theme/utils/helpers.ts
+++ b/src/theme/utils/helpers.ts
@@ -15,6 +15,12 @@
  */
 import { SECTION } from './constants';
 
+import { breakpoints } from '../../assets/theme/base';
+import { pxToRem } from '../../assets/theme/functions';
 export const getSectionHref = (section: SECTION): string => {
   return Object.keys(SECTION)[Object.values(SECTION).indexOf(section)];
 };
+
+export const isMobileView = (): boolean =>
+  // TODO Clean
+  Number(pxToRem(window.innerWidth).replace('rem', '')) < breakpoints.values.lg;


### PR DESCRIPTION
- Home page
  - Remove top margin for the first section on the mobile view
  - Fix the style of the ModelGenerationApp section on mobile view
  - Set the number max of news/posts to 3 on mobile, 6 on desktop (previously, it was always 8)
- Fix the design of the model generation app page on mobile view
- Fix the hover style on the navbar on mobile view