### PR TITLE
chore: run dependabot on friday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: friday
     open-pull-requests-limit: 2
     versioning-strategy: increase
     rebase-strategy: "disabled"
@@ -19,7 +20,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: wednesday
+      day: friday
     open-pull-requests-limit: 2
     rebase-strategy: "disabled"
     commit-message:


### PR DESCRIPTION
We mainly work on the website on Friday. So handle npm dependencies and GitHub actions update that day. This will reduce the workload and notifications during the rest of the week