### PR TITLE
refactor(navbar): rename collapsed states in the navbar components in expanded

### DIFF
--- a/src/components/material-kit/Navbar/Navbar.tsx
+++ b/src/components/material-kit/Navbar/Navbar.tsx
@@ -79,10 +79,11 @@ const InnerContainer: FC<InnerContainerProps> = ({
   dropdownStyle,
   hoverStyle,
 }) => {
-  const [collapseElement, setCollapseElement] = useState<
+  const [expandedNavDropdownElement, setExpandedNavDropdownElement] = useState<
     EventTarget & HTMLSpanElement
   >();
-  const [collapseName, setCollapseName] = useState<string>();
+  const [expandedNavDropdownName, setExpandedNavDropdownName] =
+    useState<string>();
 
   const [isOpenMobileNavbar, setIsOpenMobileNavbar] = useState(false);
   const isMobileView = isMobileViewFunc();
@@ -128,9 +129,9 @@ const InnerContainer: FC<InnerContainerProps> = ({
               routes={routes}
               isCenter={isCenter}
               hoverStyle={hoverStyle}
-              setCollapseElement={setCollapseElement}
-              setCollapseName={setCollapseName}
-              collapseName={collapseName}
+              setExpandedNavDropdownElement={setExpandedNavDropdownElement}
+              setExpandedNavDropdownName={setExpandedNavDropdownName}
+              expandedNavDropdownName={expandedNavDropdownName}
             />
           )}
 
@@ -163,10 +164,10 @@ const InnerContainer: FC<InnerContainerProps> = ({
       {!isMobileView && (
         <Dropdown
           routes={routes}
-          collapseElement={collapseElement}
-          collapseName={collapseName}
-          setCollapseElement={setCollapseElement}
-          setCollapseName={setCollapseName}
+          expandedNavDropdownElement={expandedNavDropdownElement}
+          expandedNavDropdownName={expandedNavDropdownName}
+          setExpandedNavDropdownElement={setExpandedNavDropdownElement}
+          setExpandedNavDropdownName={setExpandedNavDropdownName}
           dropdownStyle={dropdownStyle}
           hoverStyle={hoverStyle}
         />

--- a/src/components/material-kit/Navbar/desktop/Dropdown.tsx
+++ b/src/components/material-kit/Navbar/desktop/Dropdown.tsx
@@ -32,28 +32,28 @@ import { DropdownDropdown, DropdownDropdownProps } from './DropdownDropdown';
 
 export const Dropdown = ({
   routes,
-  collapseElement,
-  collapseName,
-  setCollapseElement,
-  setCollapseName,
+  expandedNavDropdownElement,
+  expandedNavDropdownName,
+  setExpandedNavDropdownElement,
+  setExpandedNavDropdownName,
   dropdownStyle,
   hoverStyle,
 }: Omit<
   NavDropdownProps,
-  | 'nestedDropdownName'
-  | 'setNestedDropdownName'
-  | 'nestedDropdownElement'
-  | 'setNestedDropdownElement'
+  | 'dropdownDropdownName'
+  | 'setDropdownDropdownName'
+  | 'dropdownDropdownElement'
+  | 'setDropdownDropdownElement'
 > &
   Omit<
     DropdownDropdownProps,
-    | 'nestedDropdownName'
-    | 'setNestedDropdownName'
-    | 'nestedDropdownElement'
-    | 'setNestedDropdownElement'
+    | 'dropdownDropdownName'
+    | 'setDropdownDropdownName'
+    | 'dropdownDropdownElement'
+    | 'setDropdownDropdownElement'
   >): JSX.Element => {
-  const [nestedDropdownName, setNestedDropdownName] = useState<string>();
-  const [nestedDropdownElement, setNestedDropdownElement] = useState<
+  const [dropdownDropdownName, setDropdownDropdownName] = useState<string>();
+  const [dropdownDropdownElement, setDropdownDropdownElement] = useState<
     EventTarget & HTMLSpanElement
   >();
 
@@ -61,22 +61,22 @@ export const Dropdown = ({
     <>
       <NavDropdown
         routes={routes}
-        collapseElement={collapseElement}
-        collapseName={collapseName}
-        setCollapseElement={setCollapseElement}
-        nestedDropdownName={nestedDropdownName}
-        setCollapseName={setCollapseName}
-        setNestedDropdownElement={setNestedDropdownElement}
-        setNestedDropdownName={setNestedDropdownName}
+        expandedNavDropdownElement={expandedNavDropdownElement}
+        expandedNavDropdownName={expandedNavDropdownName}
+        setExpandedNavDropdownElement={setExpandedNavDropdownElement}
+        dropdownDropdownName={dropdownDropdownName}
+        setExpandedNavDropdownName={setExpandedNavDropdownName}
+        setDropdownDropdownElement={setDropdownDropdownElement}
+        setDropdownDropdownName={setDropdownDropdownName}
         dropdownStyle={dropdownStyle}
         hoverStyle={hoverStyle}
       />
       <DropdownDropdown
         routes={routes}
-        nestedDropdownElement={nestedDropdownElement}
-        nestedDropdownName={nestedDropdownName}
-        setNestedDropdownElement={setNestedDropdownElement}
-        setNestedDropdownName={setNestedDropdownName}
+        dropdownDropdownElement={dropdownDropdownElement}
+        dropdownDropdownName={dropdownDropdownName}
+        setDropdownDropdownElement={setDropdownDropdownElement}
+        setDropdownDropdownName={setDropdownDropdownName}
         dropdownStyle={dropdownStyle}
         hoverStyle={hoverStyle}
       />

--- a/src/components/material-kit/Navbar/desktop/DropdownDropdown.tsx
+++ b/src/components/material-kit/Navbar/desktop/DropdownDropdown.tsx
@@ -108,38 +108,38 @@ const DropdownLink = ({
 
 export type DropdownDropdownProps = {
   routes: HeaderRoute[];
-  nestedDropdownElement?: EventTarget & HTMLSpanElement;
-  nestedDropdownName?: string;
-  setNestedDropdownElement: Dispatch<
+  dropdownDropdownElement?: EventTarget & HTMLSpanElement;
+  dropdownDropdownName?: string;
+  setDropdownDropdownElement: Dispatch<
     SetStateAction<(EventTarget & HTMLSpanElement) | undefined>
   >;
-  setNestedDropdownName: Dispatch<SetStateAction<string | undefined>>;
+  setDropdownDropdownName: Dispatch<SetStateAction<string | undefined>>;
   dropdownStyle?: React.PropsWithoutRef<MKBoxProps>;
   hoverStyle: HoverStyle;
 };
 
 export const DropdownDropdown = ({
   routes,
-  nestedDropdownElement,
-  nestedDropdownName,
-  setNestedDropdownElement,
-  setNestedDropdownName,
+  dropdownDropdownElement,
+  dropdownDropdownName,
+  setDropdownDropdownElement,
+  setDropdownDropdownName,
   dropdownStyle,
   hoverStyle,
 }: DropdownDropdownProps): JSX.Element => (
   <Popper
-    anchorEl={nestedDropdownElement}
+    anchorEl={dropdownDropdownElement}
     popperRef={null}
-    open={!!nestedDropdownName}
+    open={!!dropdownDropdownName}
     placement="right-start"
     transition
     style={{ zIndex: 10 }}
     onMouseEnter={() => {
-      setNestedDropdownElement(nestedDropdownElement);
+      setDropdownDropdownElement(dropdownDropdownElement);
     }}
     onMouseLeave={() => {
-      setNestedDropdownElement(undefined);
-      setNestedDropdownName(undefined);
+      setDropdownDropdownElement(undefined);
+      setDropdownDropdownName(undefined);
     }}
   >
     {({ TransitionProps }) => (
@@ -160,7 +160,7 @@ export const DropdownDropdown = ({
               (
                 menus.filter(
                   menu =>
-                    menu.name === nestedDropdownName &&
+                    menu.name === dropdownDropdownName &&
                     isHeaderMenuWithItems(menu),
                 ) as HeaderMenuWithItems[]
               ).map(({ items, isCollapsed }) =>

--- a/src/components/material-kit/Navbar/desktop/NavDropdown.tsx
+++ b/src/components/material-kit/Navbar/desktop/NavDropdown.tsx
@@ -136,10 +136,10 @@ const ColumnDropdownMenus = (
 
 const ListDropdownMenus = (
   menus: HeaderMenu[],
-  setNestedDropdownElement: Dispatch<
+  setDropdownDropdownElement: Dispatch<
     SetStateAction<(EventTarget & HTMLSpanElement) | undefined>
   >,
-  setNestedDropdownName: Dispatch<SetStateAction<string | undefined>>,
+  setDropdownDropdownName: Dispatch<SetStateAction<string | undefined>>,
   hoverStyle: HoverStyle,
 ): JSX.Element[] =>
   menus.map(menu =>
@@ -165,14 +165,14 @@ const ListDropdownMenus = (
           currentTarget,
         }: React.MouseEvent<HTMLSpanElement | HTMLLinkElement>) => {
           if (isHeaderMenuWithItems(menu) && menu.isCollapsed) {
-            setNestedDropdownElement(currentTarget ?? undefined);
-            setNestedDropdownName(menu.name);
+            setDropdownDropdownElement(currentTarget ?? undefined);
+            setDropdownDropdownName(menu.name);
           }
         }}
         onMouseLeave={() => {
           if (isHeaderMenuWithItems(menu) && menu.isCollapsed) {
-            setNestedDropdownElement(undefined);
-            setNestedDropdownName(undefined);
+            setDropdownDropdownElement(undefined);
+            setDropdownDropdownName(undefined);
           }
         }}
       >
@@ -226,14 +226,14 @@ const ListDropdownMenus = (
           currentTarget,
         }: React.MouseEvent<HTMLSpanElement | HTMLLinkElement>) => {
           if (isHeaderMenuWithItems(menu) && menu.isCollapsed) {
-            setNestedDropdownElement(currentTarget ?? undefined);
-            setNestedDropdownName(menu.name);
+            setDropdownDropdownElement(currentTarget ?? undefined);
+            setDropdownDropdownName(menu.name);
           }
         }}
         onMouseLeave={() => {
           if (isHeaderMenuWithItems(menu) && menu.isCollapsed) {
-            setNestedDropdownElement(undefined);
-            setNestedDropdownName(undefined);
+            setDropdownDropdownElement(undefined);
+            setDropdownDropdownName(undefined);
           }
         }}
       >
@@ -259,29 +259,29 @@ const ListDropdownMenus = (
 
 export type NavDropdownProps = {
   routes: HeaderRoute[];
-  collapseElement?: EventTarget & HTMLSpanElement;
-  collapseName?: string;
-  setCollapseElement: Dispatch<
+  expandedNavDropdownElement?: EventTarget & HTMLSpanElement;
+  expandedNavDropdownName?: string;
+  setExpandedNavDropdownElement: Dispatch<
     SetStateAction<(EventTarget & HTMLSpanElement) | undefined>
   >;
-  nestedDropdownName?: string;
-  setCollapseName: Dispatch<SetStateAction<string | undefined>>;
-  setNestedDropdownElement: Dispatch<
+  dropdownDropdownName?: string;
+  setExpandedNavDropdownName: Dispatch<SetStateAction<string | undefined>>;
+  setDropdownDropdownElement: Dispatch<
     SetStateAction<(EventTarget & HTMLSpanElement) | undefined>
   >;
-  setNestedDropdownName: Dispatch<SetStateAction<string | undefined>>;
+  setDropdownDropdownName: Dispatch<SetStateAction<string | undefined>>;
   dropdownStyle?: React.PropsWithoutRef<MKBoxProps>;
   hoverStyle: HoverStyle;
 };
 export const NavDropdown = ({
   routes,
-  collapseElement,
-  collapseName,
-  setCollapseElement,
-  nestedDropdownName,
-  setCollapseName,
-  setNestedDropdownElement,
-  setNestedDropdownName,
+  expandedNavDropdownElement,
+  expandedNavDropdownName,
+  setExpandedNavDropdownElement,
+  dropdownDropdownName,
+  setExpandedNavDropdownName,
+  setDropdownDropdownElement,
+  setDropdownDropdownName,
   dropdownStyle,
   hoverStyle,
 }: NavDropdownProps): JSX.Element => {
@@ -289,9 +289,9 @@ export const NavDropdown = ({
 
   return (
     <Popper
-      anchorEl={collapseElement}
+      anchorEl={expandedNavDropdownElement}
       popperRef={null}
-      open={!!collapseName}
+      open={!!expandedNavDropdownName}
       placement="bottom"
       transition
       style={{ zIndex: 10 }}
@@ -316,11 +316,11 @@ export const NavDropdown = ({
         },
       ]}
       onMouseEnter={() => {
-        setCollapseElement(collapseElement);
+        setExpandedNavDropdownElement(expandedNavDropdownElement);
       }}
       onMouseLeave={() => {
-        if (!nestedDropdownName) {
-          setCollapseName(undefined);
+        if (!dropdownDropdownName) {
+          setExpandedNavDropdownName(undefined);
         }
       }}
     >
@@ -339,7 +339,7 @@ export const NavDropdown = ({
                 routes.filter(
                   route =>
                     isHeaderRouteWithMenus(route) &&
-                    route.name === collapseName &&
+                    route.name === expandedNavDropdownName &&
                     route.menus,
                 ) as HeaderRouteWithMenus[]
               ).map(({ name, menus, withColumns, rowsPerColumn }) =>
@@ -349,8 +349,8 @@ export const NavDropdown = ({
                   : // Render the dropdown menu that should be display as list items
                     ListDropdownMenus(
                       menus,
-                      setNestedDropdownElement,
-                      setNestedDropdownName,
+                      setDropdownDropdownElement,
+                      setDropdownDropdownName,
                       hoverStyle,
                     ),
               )}

--- a/src/components/material-kit/Navbar/desktop/NavbarNav.tsx
+++ b/src/components/material-kit/Navbar/desktop/NavbarNav.tsx
@@ -36,20 +36,20 @@ import { Link } from '../../..';
 type NavbarNavProps = {
   routes: HeaderRoute[];
   isCenter?: boolean;
-  setCollapseElement: Dispatch<
+  setExpandedNavDropdownElement: Dispatch<
     SetStateAction<(EventTarget & HTMLSpanElement) | undefined>
   >;
-  setCollapseName: Dispatch<SetStateAction<string | undefined>>;
-  collapseName?: string;
+  setExpandedNavDropdownName: Dispatch<SetStateAction<string | undefined>>;
+  expandedNavDropdownName?: string;
   hoverStyle: HoverStyle;
 };
 
 export const NavbarNav = ({
   routes,
   isCenter,
-  setCollapseElement,
-  setCollapseName,
-  collapseName,
+  setExpandedNavDropdownElement,
+  setExpandedNavDropdownName,
+  expandedNavDropdownName,
   hoverStyle,
 }: NavbarNavProps): JSX.Element => (
   <MKBox
@@ -67,16 +67,16 @@ export const NavbarNav = ({
           hoverStyle={hoverStyle}
           icon={route.icon}
           isCollapsible={!!route.menus}
-          isCollapsed={route.name === collapseName}
+          isCollapsed={route.name === expandedNavDropdownName}
           onMouseEnter={({
             currentTarget,
           }: React.MouseEvent<HTMLDivElement>): void => {
-            setCollapseElement(currentTarget);
-            setCollapseName(route.name);
+            setExpandedNavDropdownElement(currentTarget);
+            setExpandedNavDropdownName(route.name);
           }}
           onMouseLeave={(): void => {
-            setCollapseElement(undefined);
-            setCollapseName(undefined);
+            setExpandedNavDropdownElement(undefined);
+            setExpandedNavDropdownName(undefined);
           }}
         />
       ) : (

--- a/src/components/material-kit/Navbar/mobile/NavbarNav.tsx
+++ b/src/components/material-kit/Navbar/mobile/NavbarNav.tsx
@@ -45,7 +45,7 @@ export const NavbarNav = ({
   dropdownStyle,
   hoverStyle,
 }: NavbarNavProps): JSX.Element => {
-  const [collapse, setCollapseElement] = useState<string>();
+  const [collapse, setExpandedNavDropdownElement] = useState<string>();
 
   return (
     <Collapse in={isOpen} timeout="auto" unmountOnExit>
@@ -60,7 +60,9 @@ export const NavbarNav = ({
               menus={route.menus}
               isCollapsed={isCollapsed}
               onClick={() =>
-                setCollapseElement(isCollapsed ? undefined : route.name)
+                setExpandedNavDropdownElement(
+                  isCollapsed ? undefined : route.name,
+                )
               }
               hoverStyle={hoverStyle}
             />


### PR DESCRIPTION
Based on our team's decision, we no longer require approval of the refactoring pull request. Instead, we will review and approve the refactoring once all changes related to a specific component have been completed.


Rename:

- setCollapseElement in setExpandedNavDropdownElement
- setCollapseName in setExpandedNavDropdownName
- collapseName in expandedNavDropdownName
- collapseElement in expandedNavDropdownElement
- setNestedDropdownElement in setDropdownDropdownElement
- setNestedDropdownName in setDropdownDropdownName
- nestedDropdownElement in dropdownDropdownElement
- nestedDropdownName in dropdownDropdownName