### PR TITLE
feat(page): use MaterialUI in the model generation application page

### DIFF
--- a/src/assets/theme/base/globals.ts
+++ b/src/assets/theme/base/globals.ts
@@ -60,7 +60,7 @@ export const globals: ComponentsOverrides<Theme>['MuiCssBaseline'] = {
   },
 
   body: {
-    fontSize: 'inherit',
+    fontSize: '14px',
     boxSizing: 'border-box',
     margin: 0,
     padding: 0,

--- a/src/assets/theme/index.ts
+++ b/src/assets/theme/index.ts
@@ -16,7 +16,8 @@
 
 // @mui material components
 import { createTheme, Theme } from '@mui/material';
-import responsiveFontSizes from '@mui/material/styles/responsiveFontSizes';
+
+import { responsiveFontSizes } from './responsiveFont';
 
 // Material Kit 2 React base styles
 import {

--- a/src/components/material-kit/MKTypography/MKTypographyRoot.tsx
+++ b/src/components/material-kit/MKTypography/MKTypographyRoot.tsx
@@ -77,7 +77,7 @@ export const MKTypographyRoot = styled(Typography)<MKTypographyRootProps>(({
     opacity,
     verticalAlign,
     textDecoration: 'none',
-    textTransform,
+    textTransform: textTransform ?? 'none',
     color: calculatedColor,
     letterSpacing: '-0.125px',
     fontWeight,

--- a/src/pages/model-generation-application-conditions.tsx
+++ b/src/pages/model-generation-application-conditions.tsx
@@ -43,7 +43,7 @@ const ModelGenerationApplicationConditionPage = (): JSX.Element => (
 
       <Part flexDirection="column" width="80%" marginX="auto">
         <PartTitle>Terms of Use</PartTitle>
-        <Paragraph fontSize={[1, 1, 2, 3]}>
+        <Paragraph>
           The{' '}
           <a href={'/model-generation-application'}>
             <Bold>Model Generation Application</Bold>{' '}
@@ -67,7 +67,7 @@ const ModelGenerationApplicationConditionPage = (): JSX.Element => (
             process.analytics.dev@gmail.com
           </a>
         </Paragraph>
-        <Paragraph fontSize={[1, 1, 2, 3]} marginTop={[4, 5]}>
+        <Paragraph marginTop={[4, 5]}>
           The form used to submit data is provided by&nbsp;
           <a href="https://www.jotform.com">JOTForm</a>. The following rules
           apply:
@@ -93,7 +93,7 @@ const ModelGenerationApplicationConditionPage = (): JSX.Element => (
             <li>Data is only stored in Europe (Germany)</li>
           </ul>
         </Paragraph>
-        <Paragraph fontSize={[1, 1, 2, 3]} marginTop={[4]} marginBottom={[4]}>
+        <Paragraph marginTop={[4]} marginBottom={[4]}>
           The <Bold>Process Analytics Project</Bold> collects data (name, email,
           XES file) for the sole purpose of sending you the processing results.
           <br />
@@ -117,7 +117,7 @@ const ModelGenerationApplicationConditionPage = (): JSX.Element => (
         <PartTitle>
           Disclaimer of Warranties and Limitation of Liability
         </PartTitle>
-        <Paragraph fontSize={[1, 1, 2, 3]}>
+        <Paragraph>
           <Bold>(a) Warranty Disclaimer:</Bold> THE SITE AND THE SITE CONTENT
           ARE PROVIDED STRICTLY ON AN “AS IS” AND “AS AVAILABLE” BASIS, AND THE
           PROCESS ANALYTICS PROJECT MAKES NO WARRANTY THAT THE SITE OR THE SITE
@@ -132,7 +132,7 @@ const ModelGenerationApplicationConditionPage = (): JSX.Element => (
           WARRANTY THAT THE SITE AVAILABILITY WILL BE UNINTERRUPTED, OR THE SITE
           AND/OR THE SITE CONTENT WILL BE ERROR FREE.
         </Paragraph>
-        <Paragraph fontSize={[1, 1, 2, 3]} marginTop={[4]}>
+        <Paragraph marginTop={[4]}>
           <Bold>(b) Limitation of Liability:</Bold> TO THE FULLEST EXTENT
           PERMITTED BY APPLICABLE LAW, YOU AGREE THAT THE PROCESS ANALYTICS
           PROJECT SHALL NOT BE LIABLE TO YOU FOR ANY DAMAGES ARISING OUT OF OR

--- a/src/pages/model-generation-application.tsx
+++ b/src/pages/model-generation-application.tsx
@@ -14,22 +14,14 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { FC } from 'react';
 
 import { faInfo } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { HeadProps } from 'gatsby';
 
-import { FlexProps, TextProps } from 'rebass';
-import {
-  Box,
-  Flex,
-  Heading,
-  Image,
-  Link,
-  Text,
-} from 'rebass/styled-components';
+import { Box, BoxProps, Link } from '@mui/material';
 
 import {
   SEO,
@@ -38,46 +30,58 @@ import {
   Section,
   Layout,
   PostContainer,
+  MKTypography,
 } from '../components';
 import { postsContent, footerContent, headerContent } from '../content';
 import { PAGE } from '../helper';
 import { DataProps } from '../hooks';
 
-import colors from '../assets/oldTheme/colors.json';
 import AppPreview from '../assets/images/model-generation-app/model_generation_app_preview.gif';
 import HowItWorksImg from '../assets/images/model-generation-app/how_it_works.png';
 
-export const Part = ({
+type PartTitleProps = {
+  marginBottom?: string;
+  width?: string;
+};
+
+type ParagraphProps = {
+  marginBottom?: number[];
+  marginTop?: number[];
+  marginLeft?: string[];
+  fontSize?: number[];
+  width?: string | string[];
+};
+
+export const Part: FC<React.PropsWithChildren<BoxProps>> = ({
   padding,
   children,
   ...props
-}: React.PropsWithChildren<FlexProps>): JSX.Element => {
-  return (
-    <Flex
-      marginX="16px"
-      padding={padding}
-      fontSize="1.25rem"
-      fontWeight={400}
-      lineHeight={1.625}
-      letterSpacing={'0.00938em'}
-      style={{
-        position: 'relative',
-        borderRadius: '0.75rem',
-      }}
-      {...props}
-    >
-      {children}
-    </Flex>
-  );
-};
+}) => (
+  <Box
+    display="flex"
+    marginX="16px"
+    padding={padding}
+    fontSize="1.25rem"
+    fontWeight={400}
+    lineHeight={1.625}
+    letterSpacing={'0.00938em'}
+    style={{
+      position: 'relative',
+      borderRadius: '0.75rem',
+    }}
+    {...props}
+  >
+    {children}
+  </Box>
+);
 
-export const PartWithSingleColumn = ({
-  backgroundColor,
+export const PartWithSingleColumn: FC<React.PropsWithChildren<BoxProps>> = ({
+  bgcolor,
   children,
-}: React.PropsWithChildren<FlexProps>): JSX.Element => {
+}) => {
   const background = (
     <Box
-      backgroundColor={backgroundColor}
+      bgcolor={bgcolor}
       width="100%"
       height="100%"
       style={{
@@ -90,19 +94,19 @@ export const PartWithSingleColumn = ({
           'rgba(0, 0, 0, 0.1) 0rem 0.25rem 0.375rem -0.0625rem, rgba(0, 0, 0, 0.06) 0rem 0.125rem 0.25rem -0.0625rem',
         transition: 'box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
         backgroundClip: 'border-box',
+        opacity: '0.3',
       }}
-      opacity="0.3"
       margin={0}
     />
   );
 
-  const partPadding = !backgroundColor ? '104px 24px' : 0;
-  const boxPadding = !backgroundColor ? 0 : '52px 24px';
-  const boxWidth = !backgroundColor ? 80 : 100;
+  const partPadding = !bgcolor ? '104px 24px' : 0;
+  const boxPadding = !bgcolor ? 0 : '52px 24px';
+  const boxWidth = !bgcolor ? 80 : 100;
 
   return (
     <Part padding={partPadding}>
-      {backgroundColor && background}
+      {bgcolor && background}
       <Box
         style={{ width: `${boxWidth}%`, padding: boxPadding }}
         marginX="auto"
@@ -113,54 +117,50 @@ export const PartWithSingleColumn = ({
   );
 };
 
-export const PartTitle = ({
+export const PartTitle: FC<React.PropsWithChildren<PartTitleProps>> = ({
   children,
   ...props
-}: React.PropsWithChildren<TextProps>): JSX.Element => {
-  return (
-    <Text
-      as="h3"
-      color="text"
-      marginBottom="24px"
-      fontSize="1.875rem"
-      fontWeight={700}
-      lineHeight={1.375}
-      letterSpacing="-0.125px"
-      textAlign="center"
-      {...props}
-    >
-      {children}
-    </Text>
-  );
-};
+}) => (
+  <MKTypography
+    variant="h3"
+    color="text"
+    marginBottom="24px"
+    fontSize="1.875rem"
+    fontWeight={700}
+    lineHeight={1.375}
+    letterSpacing="-0.125px"
+    textAlign="center"
+    {...props}
+  >
+    {children}
+  </MKTypography>
+);
 
-const HighlightMessage = ({
+const HighlightMessage: FC<React.PropsWithChildren<BoxProps>> = ({
   children,
-}: React.PropsWithChildren<TextProps>): JSX.Element => {
-  return (
-    <Text
-      as="h4"
-      color="secondary"
-      marginBottom="2rem"
-      paddingY={['0.5rem', '0.5rem', '1.5rem']}
-      fontSize="1.675rem"
-      fontWeight={700}
-      lineHeight={1.375}
-      letterSpacing="-0.125px"
-      textAlign="center"
-    >
-      {children}
-    </Text>
-  );
-};
+}) => (
+  <MKTypography
+    variant="h4"
+    color="secondary"
+    marginBottom="2rem"
+    paddingY={['0.5rem', '0.5rem', '1.5rem']}
+    fontSize="1.675rem"
+    fontWeight={700}
+    lineHeight={1.375}
+    letterSpacing="-0.125px"
+    textAlign="center"
+  >
+    {children}
+  </MKTypography>
+);
 
-export const Paragraph = ({
+export const Paragraph: FC<React.PropsWithChildren<ParagraphProps>> = ({
   children,
   ...props
-}: React.PropsWithChildren<TextProps>): JSX.Element => {
+}) => {
   return (
-    <Text
-      as="p"
+    <MKTypography
+      variant="body1"
       color="text"
       margin="0"
       fontSize="1.25rem"
@@ -170,36 +170,44 @@ export const Paragraph = ({
       {...props}
     >
       {children}
-    </Text>
+    </MKTypography>
   );
 };
 
-const ModelGenerationApplicationPage = (): JSX.Element => (
+const ModelGenerationApplicationPage: FC = () => (
   <Layout footerContent={footerContent} headerContent={headerContent}>
     <Section>
-      <Heading
+      <MKTypography
         textAlign="center"
-        as="h1"
+        variant="h1"
         color="primary"
         fontSize={[6, 8]}
         marginY={[5, 5, '12rem']}
       >
         Model Generation Application
-      </Heading>
+      </MKTypography>
     </Section>
     <Section>
       <Box
         style={{
+          borderRadius: '0.75rem',
+          borderColor: 'primary',
+          borderWidth: '5px',
+          borderStyle: 'solid',
+          color: 'secondary',
+          flexShrink: 0,
           boxShadow:
             'rgba(0, 0, 0, 0.1) 0rem 0.25rem 0.375rem -0.0625rem, rgba(0, 0, 0, 0.06) 0rem 0.125rem 0.25rem -0.0625rem',
         }}
       >
-        <Image
-          style={{ borderRadius: '5px' }}
-          css={{ aspectRatio: 'attr(width) / attr(height)' }}
-          src={AppPreview}
-          alt={'Model Generation Application Demo'}
-        />
+        <Box
+          sx={{
+            aspectRatio: 'attr(width) / attr(height)',
+            borderRadius: '5px',
+          }}
+        >
+          <img src={AppPreview} alt={'Model Generation Application Demo'} />
+        </Box>
       </Box>
     </Section>
     <Section>
@@ -212,7 +220,7 @@ const ModelGenerationApplicationPage = (): JSX.Element => (
       </PartWithSingleColumn>
     </Section>
     <Section>
-      <PartWithSingleColumn backgroundColor="muted">
+      <PartWithSingleColumn bgcolor="muted">
         <PartTitle marginBottom="3.25rem">How it works?</PartTitle>
         <Part
           marginTop="24px"
@@ -220,12 +228,16 @@ const ModelGenerationApplicationPage = (): JSX.Element => (
           alignItems={'center'}
           flexDirection={['column', 'row']}
         >
-          <Image
-            src={HowItWorksImg}
-            alt={'Generation Model Application Demo'}
+          <Box
             width={['100%', '45%']}
+            height="auto"
             marginBottom={['3.25rem', 0]}
-          />
+          >
+            <img
+              src={HowItWorksImg}
+              alt={'Generation Model Application Demo'}
+            />
+          </Box>
           <Paragraph width={['100%', '40%']} fontSize={[1, 1, 2, 3]}>
             The Model Generation Application is a{' '}
             <Link href="https://shiny.rstudio.com/">shiny R application</Link>{' '}
@@ -257,24 +269,25 @@ const ModelGenerationApplicationPage = (): JSX.Element => (
         width={['100%', '80%']}
         marginX="auto"
       >
-        <Flex
+        <Box
+          display="flex"
           width={['5rem', '5.5rem', '6.875rem']}
           height={['5rem', '5.5rem', '6.875rem']}
           alignItems="center"
           marginBottom={['3.25rem', 0]}
           style={{
             borderRadius: '0.75rem',
-            borderColor: colors.primary,
+            borderColor: 'primary',
             borderWidth: '5px',
             borderStyle: 'solid',
-            color: colors.secondary,
+            color: 'secondary',
             flexShrink: 0,
             boxShadow:
               'rgba(0, 0, 0, 0.1) 0rem 0.25rem 0.375rem -0.0625rem, rgba(0, 0, 0, 0.06) 0rem 0.125rem 0.25rem -0.0625rem',
           }}
         >
           <FontAwesomeIcon icon={faInfo} width="100%" height="100%" size="2x" />
-        </Flex>
+        </Box>
         <Paragraph
           fontSize={[1, 1, 2, 3]}
           marginLeft={['2rem', '3rem', '5rem']}
@@ -332,6 +345,6 @@ export default ModelGenerationApplicationPage;
  * Valid tags inside the Head function are: link, meta, style, title, base, script, and noscript.
  * See https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-head/
  */
-export const Head = ({ location }: HeadProps<DataProps>): JSX.Element => (
+export const Head: FC<HeadProps<DataProps>> = ({ location }) => (
   <SEO title={PAGE.modelGenerationApplication} pathname={location.pathname} />
 );

--- a/src/pages/model-generation-application.tsx
+++ b/src/pages/model-generation-application.tsx
@@ -48,7 +48,6 @@ type ParagraphProps = {
   marginBottom?: number[];
   marginTop?: number[];
   marginLeft?: string[];
-  fontSize?: number[];
   width?: string | string[];
 };
 
@@ -61,10 +60,6 @@ export const Part: FC<React.PropsWithChildren<BoxProps>> = ({
     display="flex"
     marginX="16px"
     padding={padding}
-    fontSize="1.25rem"
-    fontWeight={400}
-    lineHeight={1.625}
-    letterSpacing={'0.00938em'}
     style={{
       position: 'relative',
       borderRadius: '0.75rem',
@@ -125,10 +120,6 @@ export const PartTitle: FC<React.PropsWithChildren<PartTitleProps>> = ({
     variant="h3"
     color="text"
     marginBottom="24px"
-    fontSize="1.875rem"
-    fontWeight={700}
-    lineHeight={1.375}
-    letterSpacing="-0.125px"
     textAlign="center"
     {...props}
   >
@@ -144,10 +135,6 @@ const HighlightMessage: FC<React.PropsWithChildren<BoxProps>> = ({
     color="secondary"
     marginBottom="2rem"
     paddingY={['0.5rem', '0.5rem', '1.5rem']}
-    fontSize="1.675rem"
-    fontWeight={700}
-    lineHeight={1.375}
-    letterSpacing="-0.125px"
     textAlign="center"
   >
     {children}
@@ -157,22 +144,11 @@ const HighlightMessage: FC<React.PropsWithChildren<BoxProps>> = ({
 export const Paragraph: FC<React.PropsWithChildren<ParagraphProps>> = ({
   children,
   ...props
-}) => {
-  return (
-    <MKTypography
-      variant="body1"
-      color="text"
-      margin="0"
-      fontSize="1.25rem"
-      fontWeight={300}
-      lineHeight={1.625}
-      letterSpacing="-0.125px"
-      {...props}
-    >
-      {children}
-    </MKTypography>
-  );
-};
+}) => (
+  <MKTypography variant="body1" color="text" margin="0" {...props}>
+    {children}
+  </MKTypography>
+);
 
 const ModelGenerationApplicationPage: FC = () => (
   <Layout footerContent={footerContent} headerContent={headerContent}>
@@ -181,33 +157,26 @@ const ModelGenerationApplicationPage: FC = () => (
         textAlign="center"
         variant="h1"
         color="primary"
-        fontSize={[6, 8]}
-        marginY={[5, 5, '12rem']}
+        mt={[5, 5, 6]}
+        mb={[3, 8, 12]}
       >
         Model Generation Application
       </MKTypography>
     </Section>
     <Section>
       <Box
-        style={{
-          borderRadius: '0.75rem',
-          borderColor: 'primary',
-          borderWidth: '5px',
-          borderStyle: 'solid',
-          color: 'secondary',
-          flexShrink: 0,
+        marginX={[0, 0, 0, 5]}
+        sx={{
+          borderRadius: '5px',
           boxShadow:
             'rgba(0, 0, 0, 0.1) 0rem 0.25rem 0.375rem -0.0625rem, rgba(0, 0, 0, 0.06) 0rem 0.125rem 0.25rem -0.0625rem',
         }}
       >
-        <Box
-          sx={{
-            aspectRatio: 'attr(width) / attr(height)',
-            borderRadius: '5px',
-          }}
-        >
-          <img src={AppPreview} alt={'Model Generation Application Demo'} />
-        </Box>
+        <img
+          src={AppPreview}
+          alt={'Model Generation Application Demo'}
+          style={{ borderRadius: '5px' }}
+        />
       </Box>
     </Section>
     <Section>
@@ -238,7 +207,7 @@ const ModelGenerationApplicationPage: FC = () => (
               alt={'Generation Model Application Demo'}
             />
           </Box>
-          <Paragraph width={['100%', '40%']} fontSize={[1, 1, 2, 3]}>
+          <Paragraph width={['100%', '40%']}>
             The Model Generation Application is a{' '}
             <Link href="https://shiny.rstudio.com/">shiny R application</Link>{' '}
             that takes an event log file in{' '}
@@ -271,27 +240,29 @@ const ModelGenerationApplicationPage: FC = () => (
       >
         <Box
           display="flex"
+          flexShrink={0}
+          alignItems="center"
           width={['5rem', '5.5rem', '6.875rem']}
           height={['5rem', '5.5rem', '6.875rem']}
-          alignItems="center"
           marginBottom={['3.25rem', 0]}
-          style={{
+          sx={{
+            color: 'secondary.main',
+            border: '5px solid',
             borderRadius: '0.75rem',
-            borderColor: 'primary',
-            borderWidth: '5px',
-            borderStyle: 'solid',
-            color: 'secondary',
-            flexShrink: 0,
+            borderColor: 'primary.main',
             boxShadow:
               'rgba(0, 0, 0, 0.1) 0rem 0.25rem 0.375rem -0.0625rem, rgba(0, 0, 0, 0.06) 0rem 0.125rem 0.25rem -0.0625rem',
           }}
         >
-          <FontAwesomeIcon icon={faInfo} width="100%" height="100%" size="2x" />
+          <FontAwesomeIcon
+            icon={faInfo}
+            width="100%"
+            height="100%"
+            size="2x"
+            color="inherit"
+          />
         </Box>
-        <Paragraph
-          fontSize={[1, 1, 2, 3]}
-          marginLeft={['2rem', '3rem', '5rem']}
-        >
+        <Paragraph marginLeft={['2rem', '3rem', '5rem']}>
           This tool is currently in preview. We are working on improving the
           performance and usability of the tool.
           <br /> <br />
@@ -304,7 +275,7 @@ const ModelGenerationApplicationPage: FC = () => (
     <Section>
       <Part
         id={'form'}
-        marginBottom="124px"
+        marginY={[0, 0, 0, 3]}
         style={{
           boxSizing: 'border-box',
           flexFlow: 'row wrap',


### PR DESCRIPTION
Based on our team's decision, we no longer require approval of the refactoring pull request. Instead, we will review and approve the refactoring once all changes related to a specific component have been completed.

⚠️ The text doesn't have the same font size as the original design, due to the `Typography` of Material Kit. But, I think it make the rendering more readable.  
It's possible to adjust after all changes are done in the end.

Covers #831