### PR TITLE
feat(page): use MaterialUI in the model generation application conditions page

### DIFF
--- a/src/pages/model-generation-application-conditions.tsx
+++ b/src/pages/model-generation-application-conditions.tsx
@@ -16,9 +16,9 @@
 
 import React, { FC } from 'react';
 
-import { styled } from '@mui/material';
+import { styled, Link as MaterialLink } from '@mui/material';
 
-import { HeadProps } from 'gatsby';
+import { HeadProps, Link as GatsbyLink } from 'gatsby';
 
 import { SEO, Section, Layout, MKTypography } from '../components';
 import { DataProps } from '../hooks';
@@ -34,7 +34,8 @@ const ModelGenerationApplicationConditionPage: FC = () => (
         textAlign="center"
         variant="h1"
         color="primary"
-        marginY={[5, 5, '12rem']}
+        mt={[5, 5, 6]}
+        mb={[3, 8, 12]}
       >
         Usage conditions of Model Generation Application
       </MKTypography>
@@ -43,9 +44,9 @@ const ModelGenerationApplicationConditionPage: FC = () => (
         <PartTitle>Terms of Use</PartTitle>
         <Paragraph>
           The{' '}
-          <a href={'/model-generation-application'}>
+          <GatsbyLink to={'/model-generation-application'}>
             <Bold>Model Generation Application</Bold>{' '}
-          </a>
+          </GatsbyLink>
           is edited by:
           <br />
           <code>
@@ -61,21 +62,25 @@ const ModelGenerationApplicationConditionPage: FC = () => (
           <br />
           <br />
           Contact:{' '}
-          <a href="mailto:process.analytics.dev@gmail.com">
+          <MaterialLink href="mailto:process.analytics.dev@gmail.com">
             process.analytics.dev@gmail.com
-          </a>
+          </MaterialLink>
         </Paragraph>
         <Paragraph marginTop={[4, 5]}>
           The form used to submit data is provided by&nbsp;
-          <a href="https://www.jotform.com">JOTForm</a>. The following rules
-          apply:
+          <MaterialLink href="https://www.jotform.com">JOTForm</MaterialLink>.
+          The following rules apply:
           <ul>
             <li>
-              <a href="https://www.jotform.com/terms/">JOTForm terms</a>
+              <MaterialLink href="https://www.jotform.com/terms/">
+                JOTForm terms
+              </MaterialLink>
             </li>
             <li>
-              <a href="https://www.jotform.com/privacy/">JOTForm privacy</a>. In
-              particular, please read the following paragraphs
+              <MaterialLink href="https://www.jotform.com/privacy/">
+                JOTForm privacy
+              </MaterialLink>
+              . In particular, please read the following paragraphs
               <ul>
                 <li>
                   <i>"INFORMATION WE COLLECT / From Form Responders"</i>

--- a/src/pages/model-generation-application-conditions.tsx
+++ b/src/pages/model-generation-application-conditions.tsx
@@ -14,32 +14,30 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { FC } from 'react';
+
+import { styled } from '@mui/material';
 
 import { HeadProps } from 'gatsby';
 
-import { Heading } from 'rebass/styled-components';
-import styled from 'styled-components';
-
-import { SEO, Section, Layout } from '../components';
+import { SEO, Section, Layout, MKTypography } from '../components';
 import { DataProps } from '../hooks';
 import { footerContent, headerContent } from '../content';
 import { PAGE } from '../helper';
 
 import { Part, Paragraph, PartTitle } from './model-generation-application';
 
-const ModelGenerationApplicationConditionPage = (): JSX.Element => (
+const ModelGenerationApplicationConditionPage: FC = () => (
   <Layout footerContent={footerContent} headerContent={headerContent}>
     <Section>
-      <Heading
+      <MKTypography
         textAlign="center"
-        as="h1"
+        variant="h1"
         color="primary"
-        fontSize={[6, 8]}
         marginY={[5, 5, '12rem']}
       >
         Usage conditions of Model Generation Application
-      </Heading>
+      </MKTypography>
 
       <Part flexDirection="column" width="80%" marginX="auto">
         <PartTitle>Terms of Use</PartTitle>
@@ -93,7 +91,7 @@ const ModelGenerationApplicationConditionPage = (): JSX.Element => (
             <li>Data is only stored in Europe (Germany)</li>
           </ul>
         </Paragraph>
-        <Paragraph marginTop={[4]} marginBottom={[4]}>
+        <Paragraph marginTop={4} marginBottom={4}>
           The <Bold>Process Analytics Project</Bold> collects data (name, email,
           XES file) for the sole purpose of sending you the processing results.
           <br />
@@ -132,7 +130,7 @@ const ModelGenerationApplicationConditionPage = (): JSX.Element => (
           WARRANTY THAT THE SITE AVAILABILITY WILL BE UNINTERRUPTED, OR THE SITE
           AND/OR THE SITE CONTENT WILL BE ERROR FREE.
         </Paragraph>
-        <Paragraph marginTop={[4]}>
+        <Paragraph marginTop={4}>
           <Bold>(b) Limitation of Liability:</Bold> TO THE FULLEST EXTENT
           PERMITTED BY APPLICABLE LAW, YOU AGREE THAT THE PROCESS ANALYTICS
           PROJECT SHALL NOT BE LIABLE TO YOU FOR ANY DAMAGES ARISING OUT OF OR
@@ -152,7 +150,7 @@ const ModelGenerationApplicationConditionPage = (): JSX.Element => (
   </Layout>
 );
 
-const Bold = styled.b`
+const Bold = styled('b')`
   font-weight: 700;
 `;
 export default ModelGenerationApplicationConditionPage;

--- a/src/pages/model-generation-application.tsx
+++ b/src/pages/model-generation-application.tsx
@@ -45,9 +45,9 @@ type PartTitleProps = {
 };
 
 type ParagraphProps = {
-  marginBottom?: number[];
-  marginTop?: number[];
-  marginLeft?: string[];
+  marginBottom?: number | number[];
+  marginTop?: number | number[];
+  marginLeft?: string | string[];
   width?: string | string[];
 };
 
@@ -145,7 +145,7 @@ export const Paragraph: FC<React.PropsWithChildren<ParagraphProps>> = ({
   children,
   ...props
 }) => (
-  <MKTypography variant="body1" color="text" margin="0" {...props}>
+  <MKTypography variant="body2" color="text" margin="0" {...props}>
     {children}
   </MKTypography>
 );


### PR DESCRIPTION
Based on our team's decision, we no longer require approval of the refactoring pull request. Instead, we will review and approve the refactoring once all changes related to a specific component have been completed.

⚠️ The text doesn't have the same font size as the original design, due to the `Typography` of Material Kit. But, I think it make the rendering more readable.  
It's possible to adjust after all changes are done in the end.

Covers #831