### PR TITLE
feat(model generation app): use MaterialUI in the ModelGenerationApplication components

### DIFF
--- a/src/components/modelGenerationApp/CardWithIcon.tsx
+++ b/src/components/modelGenerationApp/CardWithIcon.tsx
@@ -37,61 +37,32 @@ export const CardWithIcon: FC<CardWithIconProps> = ({
 }) => (
   <Box
     style={{
-      /*      fontSize: '1.25rem',
-      fontWeight: '400',
-      lineHeight: '1',
-      letterSpacing: '0.00938em',*/
       padding: '16px',
       textAlign: 'center',
     }}
   >
-    <MKTypography
-      variant="h2"
-      style={{
-        /*        fontSize: '2.25rem',
-        fontWeight: '700',
-        lineHeight: '1.3',
-        letterSpacing: '-0.125px',*/
-        padding: '0',
-      }}
-    >
+    <MKTypography variant="h3" display="block">
       <FontAwesomeIcon
         icon={icon}
         color={iconColor}
         style={{
-          width: '1em',
-          height: '1em',
+          width: '1.75rem',
+          height: '1.75rem',
           overflow: 'hidden',
           display: 'inline-block',
-          padding: '0',
         }}
       />
     </MKTypography>
     <MKTypography
-      variant={'h5'}
-      style={{
-        margin: '8px 0px 12px',
-        /*        display: 'block',
-        fontWeight: '700',
-        letterSpacing: '-0.125px',*/
-      }}
+      variant="body1"
+      display="block"
+      fontWeight="bold"
+      mt={1}
+      mb={1.5}
     >
       {title}
     </MKTypography>
-    <MKTypography
-      variant="body1"
-      paddingX="0"
-      margin="0"
-      style={
-        {
-          /* fontSize: '1rem',
-        fontWeight: '300',
-        lineHeight: '1.6',
-        display: 'block',
-        letterSpacing: '-0.125px',*/
-        }
-      }
-    >
+    <MKTypography variant="body2" display="block" color="text">
       {description}
     </MKTypography>
   </Box>

--- a/src/components/modelGenerationApp/CardWithIcon.tsx
+++ b/src/components/modelGenerationApp/CardWithIcon.tsx
@@ -13,10 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import React, { FC } from 'react';
+
+import { Box } from '@mui/material';
+
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import React from 'react';
-import { Box, Heading, Text } from 'rebass/styled-components';
+
+import { MKTypography } from '../material-kit';
 
 export interface CardWithIconProps {
   icon: IconProp;
@@ -24,70 +28,71 @@ export interface CardWithIconProps {
   title: string;
   description: string;
 }
-export const CardWithIcon = ({
+
+export const CardWithIcon: FC<CardWithIconProps> = ({
   iconColor,
   icon,
   title,
   description,
-}: CardWithIconProps): JSX.Element => {
-  return (
-    <Box
+}) => (
+  <Box
+    style={{
+      /*      fontSize: '1.25rem',
+      fontWeight: '400',
+      lineHeight: '1',
+      letterSpacing: '0.00938em',*/
+      padding: '16px',
+      textAlign: 'center',
+    }}
+  >
+    <MKTypography
+      variant="h2"
       style={{
-        fontSize: '1.25rem',
-        fontWeight: '400',
-        lineHeight: '1',
-        letterSpacing: '0.00938em',
-        padding: '16px',
-        textAlign: 'center',
+        /*        fontSize: '2.25rem',
+        fontWeight: '700',
+        lineHeight: '1.3',
+        letterSpacing: '-0.125px',*/
+        padding: '0',
       }}
     >
-      <Heading
-        as={'h2'}
+      <FontAwesomeIcon
+        icon={icon}
+        color={iconColor}
         style={{
-          fontSize: '2.25rem',
-          fontWeight: '700',
-          lineHeight: '1.3',
-          letterSpacing: '-0.125px',
+          width: '1em',
+          height: '1em',
+          overflow: 'hidden',
+          display: 'inline-block',
           padding: '0',
         }}
-      >
-        <FontAwesomeIcon
-          icon={icon}
-          color={iconColor}
-          style={{
-            width: '1em',
-            height: '1em',
-            overflow: 'hidden',
-            display: 'inline-block',
-            padding: '0',
-          }}
-        />
-      </Heading>
-      <Text
-        as={'span'}
-        style={{
-          margin: '8px 0px 12px',
-          display: 'block',
-          fontWeight: '700',
-          letterSpacing: '-0.125px',
-        }}
-      >
-        {title}
-      </Text>
-      <Text
-        as={'p'}
-        paddingX={'0'}
-        margin={'0'}
-        style={{
-          fontSize: '1rem',
-          fontWeight: '300',
-          lineHeight: '1.6',
-          display: 'block',
-          letterSpacing: '-0.125px',
-        }}
-      >
-        {description}
-      </Text>
-    </Box>
-  );
-};
+      />
+    </MKTypography>
+    <MKTypography
+      variant={'h5'}
+      style={{
+        margin: '8px 0px 12px',
+        /*        display: 'block',
+        fontWeight: '700',
+        letterSpacing: '-0.125px',*/
+      }}
+    >
+      {title}
+    </MKTypography>
+    <MKTypography
+      variant="body1"
+      paddingX="0"
+      margin="0"
+      style={
+        {
+          /* fontSize: '1rem',
+        fontWeight: '300',
+        lineHeight: '1.6',
+        display: 'block',
+        letterSpacing: '-0.125px',*/
+        }
+      }
+    >
+      {description}
+    </MKTypography>
+  </Box>
+);

--- a/src/components/modelGenerationApp/Features.tsx
+++ b/src/components/modelGenerationApp/Features.tsx
@@ -13,14 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React from 'react';
-import { Box, BoxProps, Flex } from 'rebass/styled-components';
+import React, { FC, PropsWithChildren } from 'react';
+
+import { Box, BoxProps } from '@mui/material';
 
 import { CardWithIcon } from './CardWithIcon';
 
-const CardBox = ({
-  children,
-}: React.PropsWithChildren<BoxProps>): JSX.Element => (
+const CardBox: FC<PropsWithChildren<BoxProps>> = ({ children }) => (
   <Box
     paddingLeft={'24px'}
     paddingTop={'24px'}
@@ -31,46 +30,45 @@ const CardBox = ({
   </Box>
 );
 
-export const Features = (): JSX.Element => {
-  return (
-    <Flex
-      flexDirection={['column', 'column', 'row']}
-      flexWrap="wrap"
-      style={{
-        fontSize: '1.25rem',
-        fontWeight: '400',
-        lineHeight: '1.625',
-        letterSpacing: '0.00938em',
-        boxSizing: 'border-box',
-        marginTop: '-24px',
-        width: 'calc(100% + 24px)',
-        marginLeft: '-24px',
-      }}
-    >
-      <CardBox>
-        <CardWithIcon
-          iconColor="muted"
-          icon="lightbulb"
-          title="Free tool"
-          description="Generate and visualize process activities in BPMN Standards."
-        />
-      </CardBox>
-      <CardBox>
-        <CardWithIcon
-          iconColor="muted"
-          icon="tools"
-          title="Simple usage"
-          description="Provide event logs and select the format of the diagram to be generated."
-        />
-      </CardBox>
-      <CardBox>
-        <CardWithIcon
-          iconColor="muted"
-          icon="bolt-lightning"
-          title="Process Analytics"
-          description="Built by assembling various libraries provided by the Process Analytics project."
-        />
-      </CardBox>
-    </Flex>
-  );
-};
+export const Features = (): JSX.Element => (
+  <Box
+    display="flex"
+    flexDirection={['column', 'column', 'row']}
+    flexWrap="wrap"
+    style={{
+      /*      fontSize: '1.25rem',
+      fontWeight: '400',
+      lineHeight: '1.625',
+      letterSpacing: '0.00938em',*/
+      boxSizing: 'border-box',
+      marginTop: '-24px',
+      width: 'calc(100% + 24px)',
+      marginLeft: '-24px',
+    }}
+  >
+    <CardBox>
+      <CardWithIcon
+        iconColor="muted"
+        icon="lightbulb"
+        title="Free tool"
+        description="Generate and visualize process activities in BPMN Standards."
+      />
+    </CardBox>
+    <CardBox>
+      <CardWithIcon
+        iconColor="muted"
+        icon="tools"
+        title="Simple usage"
+        description="Provide event logs and select the format of the diagram to be generated."
+      />
+    </CardBox>
+    <CardBox>
+      <CardWithIcon
+        iconColor="muted"
+        icon="bolt-lightning"
+        title="Process Analytics"
+        description="Built by assembling various libraries provided by the Process Analytics project."
+      />
+    </CardBox>
+  </Box>
+);

--- a/src/pages/model-generation-application.tsx
+++ b/src/pages/model-generation-application.tsx
@@ -117,7 +117,7 @@ export const PartTitle: FC<React.PropsWithChildren<PartTitleProps>> = ({
   ...props
 }) => (
   <MKTypography
-    variant="h3"
+    variant="h2"
     color="text"
     marginBottom="24px"
     textAlign="center"
@@ -131,11 +131,13 @@ const HighlightMessage: FC<React.PropsWithChildren<BoxProps>> = ({
   children,
 }) => (
   <MKTypography
-    variant="h4"
+    variant="body1"
     color="secondary"
-    marginBottom="2rem"
     paddingY={['0.5rem', '0.5rem', '1.5rem']}
     textAlign="center"
+    sx={{
+      fontWeight: 700,
+    }}
   >
     {children}
   </MKTypography>


### PR DESCRIPTION
Based on our team's decision, we no longer require approval of the refactoring pull request. Instead, we will review and approve the refactoring once all changes related to a specific component have been completed.  
  
:warning: The text doesn't have the same font size as the original design, due to the `Typography` of Material Kit. But, I think it make the rendering more readable.  
It's possible to adjust after all changes are done in the end.

Covers [#831](https://github.com/process-analytics/process-analytics.dev/issues/831)