### PR TITLE
feat(theme): use the config from Material Kit for the theme of Material UI

### DIFF
--- a/src/assets/theme/base/borders.ts
+++ b/src/assets/theme/base/borders.ts
@@ -17,36 +17,35 @@
 /**
  * The base border styles for the Material Kit 2 React.
  * You can add new border width, border color or border radius using this file.
- * You can customized the borders value for the entire Material Kit 2 React using thie file.
+ * You can customize the borders value for the entire Material Kit 2 React using this file.
  */
+
+import { Borders } from '@mui/material/styles';
 
 // Material Kit 2 React Base Styles
 import { palette } from './colors';
 
-// Material Kit 2 React Helper Functions
-import { pxToRem } from '../functions/pxToRem';
-
 const { grey } = palette;
 
-export const borders = {
+export const borders: Borders = {
   borderColor: grey ? grey[300] : undefined,
 
   borderWidth: {
-    0: pxToRem(0),
-    1: pxToRem(1),
-    2: pxToRem(2),
-    3: pxToRem(3),
-    4: pxToRem(4),
-    5: pxToRem(5),
+    xs: '0rem',
+    sm: '0.0625rem',
+    md: '0.125rem',
+    lg: '0.1875rem',
+    xl: '0.25rem',
+    xxl: '0.3125rem',
   },
 
   borderRadius: {
-    xs: pxToRem(1.6),
-    sm: pxToRem(2),
-    md: pxToRem(6),
-    lg: pxToRem(8),
-    xl: pxToRem(12),
-    xxl: pxToRem(16),
-    section: pxToRem(160),
+    xs: '0.1rem',
+    sm: '0.125rem',
+    md: '0.375rem',
+    lg: '0.5rem',
+    xl: '0.75rem',
+    xxl: '1rem',
+    section: '10rem',
   },
 };

--- a/src/assets/theme/base/globals.ts
+++ b/src/assets/theme/base/globals.ts
@@ -20,9 +20,8 @@ import { ComponentsOverrides } from '@mui/material/styles/overrides';
 
 // Material Kit 2 React Base Styles
 import { palette } from './colors';
-import { typography } from './typography';
 
-const { info, secondary, background, text } = palette;
+const { info, secondary } = palette;
 
 export const globals: ComponentsOverrides<Theme>['MuiCssBaseline'] = {
   html: {
@@ -37,43 +36,10 @@ export const globals: ComponentsOverrides<Theme>['MuiCssBaseline'] = {
   '*, *::before, *::after': {
     margin: 0,
     padding: 0,
-    boxSizing: 'border-box',
-  },
-
-  header: {
-    width: '100%',
-    display: 'block',
-    fontFamily: '"Open Sans",Helvetica,Arial,sans-serif',
-    fontSize: 'inherit',
-    margin: '0',
-    padding: '0',
-    border: '0',
-    minHeight: '0',
-    position: 'relative',
-    backgroundColor: '#f8f8f8',
-    borderRadius: '4px',
-
-    '&::before, &::after': {
-      display: 'table',
-      content: '" "',
-    },
   },
 
   body: {
-    fontSize: '14px',
-    boxSizing: 'border-box',
-    margin: 0,
-    padding: 0,
-    width: '100vw',
-    overflowX: 'hidden',
-    fontFamily: typography.fontFamily,
-    background: background?.default,
-    color: text?.primary,
-    lineHeight: 1.5,
-  },
-
-  p: {
-    margin: '0 0 10px',
+    fontSize: '10px',
   },
 
   img: {
@@ -82,12 +48,8 @@ export const globals: ComponentsOverrides<Theme>['MuiCssBaseline'] = {
     border: 0,
   },
 
-  'a[href]': {
-    cursor: 'pointer',
-  },
   a: {
     textDecoration: 'none',
-    backgroundColor: 'transparent',
   },
   'a.link, .link, a.link:link, .link:link, a.link:visited, .link:visited': {
     color: `${(secondary as SimplePaletteColorOptions)?.main} !important`,

--- a/src/assets/theme/base/typography.ts
+++ b/src/assets/theme/base/typography.ts
@@ -26,7 +26,6 @@ const baseHeadingProperties = {
   color: 'inherit',
   fontWeight: 700,
   fontFamily: 'inherit',
-  margin: '1.5rem 0 1.5rem 0',
 };
 
 export const typography: TypographyOptions = {

--- a/src/assets/theme/components/muiCard.ts
+++ b/src/assets/theme/components/muiCard.ts
@@ -16,12 +16,30 @@
 
 import { Components, Theme } from '@mui/material';
 
+import { borders, boxShadows } from '../base';
+import { rgba } from '../functions';
+
+const { borderWidth, borderRadius } = borders;
+const { md } = boxShadows;
+
 export const MuiCard: Components<Theme>['MuiCard'] = {
   styleOverrides: {
-    root: {
+    root: ({ theme: { palette } }) => ({
+      display: 'flex',
+      flexDirection: 'column',
+      position: 'relative',
+      minWidth: 0,
+      wordWrap: 'break-word',
+      backgroundColor: palette.quaternary.main,
+      backgroundClip: 'border-box',
+      border: `${borderWidth.xs} solid ${rgba('#000000', 0.125)}`,
+      borderRadius: borderRadius.xl,
+      boxShadow: md,
+      overflow: 'visible',
+
       ':hover': {
-        boxShadow: '0 12px 16px rgba(0, 0, 0, 0.2)',
+        boxShadow: '0 0.75rem 1rem rgba(0, 0, 0, 0.2)',
       },
-    },
+    }),
   },
 };

--- a/src/assets/theme/components/muiContainer.ts
+++ b/src/assets/theme/components/muiContainer.ts
@@ -52,8 +52,8 @@ const buildMaxWidthByBreakpoint = (
 export const MuiContainer: Components<Theme>['MuiContainer'] = {
   styleOverrides: {
     root: ({ theme }: { theme: Theme }) => ({
-      paddingRight: `2rem !important`,
-      paddingLeft: `2rem !important`,
+      paddingRight: '2rem !important',
+      paddingLeft: '2rem !important',
       marginRight: 'auto !important',
       marginLeft: 'auto !important',
       width: '100% !important',

--- a/src/assets/theme/components/muiIcon.ts
+++ b/src/assets/theme/components/muiIcon.ts
@@ -31,9 +31,6 @@
 
 import { Components, Theme } from '@mui/material';
 
-// Material Kit 2 React helper functions
-import { pxToRem } from '../functions/pxToRem';
-
 export const MuiIcon: Components<Theme>['MuiIcon'] = {
   defaultProps: {
     baseClassName: 'material-icons-round',
@@ -46,11 +43,11 @@ export const MuiIcon: Components<Theme>['MuiIcon'] = {
     },
 
     fontSizeSmall: {
-      fontSize: `${pxToRem(20)} !important`,
+      fontSize: '1.25rem !important',
     },
 
     fontSizeLarge: {
-      fontSize: `${pxToRem(36)} !important`,
+      fontSize: '2.25rem !important',
     },
   },
 };

--- a/src/assets/theme/components/muiSvgIcon.ts
+++ b/src/assets/theme/components/muiSvgIcon.ts
@@ -31,9 +31,6 @@
 
 import { Components, Theme } from '@mui/material';
 
-// Material Kit 2 React helper functions
-import { pxToRem } from '../functions/pxToRem';
-
 export const MuiSvgIcon: Components<Theme>['MuiSvgIcon'] = {
   defaultProps: {
     fontSize: 'inherit',
@@ -45,11 +42,11 @@ export const MuiSvgIcon: Components<Theme>['MuiSvgIcon'] = {
     },
 
     fontSizeSmall: {
-      fontSize: `${pxToRem(20)} !important`,
+      fontSize: '1.25rem !important',
     },
 
     fontSizeLarge: {
-      fontSize: `${pxToRem(36)} !important`,
+      fontSize: '2.25rem !important',
     },
   },
 };

--- a/src/assets/theme/components/muiTooltip.ts
+++ b/src/assets/theme/components/muiTooltip.ts
@@ -30,19 +30,13 @@
  */
 
 import { Components, Theme } from '@mui/material';
+
 // @mui material components
 import Fade from '@mui/material/Fade';
 
-import { grey } from '@mui/material/colors';
-
 // Material Kit 2 React base styles
-import { typography } from '../base/typography';
 import { borders } from '../base/borders';
 
-// Material Kit 2 React helper functions
-import { pxToRem } from '../functions/pxToRem';
-
-const { fontWeightRegular } = typography;
 const { borderRadius } = borders;
 
 export const MuiTooltip: Components<Theme>['MuiTooltip'] = {
@@ -52,20 +46,20 @@ export const MuiTooltip: Components<Theme>['MuiTooltip'] = {
   },
 
   styleOverrides: {
-    tooltip: {
-      maxWidth: pxToRem(200),
-      backgroundColor: grey[900],
-      color: grey[50],
+    tooltip: ({ theme: { typography } }) => ({
+      maxWidth: '12.5rem',
+      backgroundColor: 'black',
+      color: '#f0f2f5',
       fontSize: '0.875rem',
-      fontWeight: fontWeightRegular,
+      fontWeight: typography.fontWeightRegular,
       textAlign: 'center',
       borderRadius: borderRadius.md,
       opacity: 0.7,
-      padding: `${pxToRem(5)} ${pxToRem(8)} ${pxToRem(4)}`,
-    },
+      padding: '0.3125rem 0.5rem 0.25rem',
+    }),
 
     arrow: {
-      color: grey[900],
+      color: 'black',
     },
   },
 };

--- a/src/types/@mui-material-styles.d.ts
+++ b/src/types/@mui-material-styles.d.ts
@@ -72,14 +72,7 @@ declare module '@mui/material/styles' {
   };
   type Borders = {
     borderColor?: string;
-    borderWidth: {
-      0: string;
-      1: string;
-      2: string;
-      3: string;
-      4: string;
-      5: string;
-    };
+    borderWidth: Omi<BorderRadius, 'section'>;
     borderRadius: BorderRadius;
   };
 


### PR DESCRIPTION
Currently, there is a mix in the configuration of the Material UI theme. We use a part of the configuration from Material Kit and a part of the old CSS configuration from the old theme.

To avoid to have to fix it at each new integration of component from Material Kit or Material UI, I do the following actions:
- Removed the configuration of the old theme in the Material UI theme,
- Uses the theme configuration from Material Kit for the existing configuration of Material UI. 


ℹ️ Based on our team's decision, we no longer require approval of the refactoring pull request. Instead, we will review and approve the refactoring once all changes related to a specific component have been completed.