### PR TITLE
feat(mdx): use MaterialUI in the styled components for the MDX content

### DIFF
--- a/src/components/MarkdownComponents.tsx
+++ b/src/components/MarkdownComponents.tsx
@@ -13,76 +13,46 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { PropsWithChildren, ReactElement } from 'react';
-import { Text } from 'rebass';
-import styled from 'styled-components';
+import React from 'react';
+
+import { Link as MaterialLink } from '@mui/material';
+import { Link as GatsbyLink } from 'gatsby';
+
 import { MDXComponents } from 'mdx/types';
 
-const StyledLink = styled.a`
-  display: inline-block;
-  transition:
-    color 250ms,
-    text-shadow 250ms;
-  color: ${({ theme }) => theme.colors.text};
-  cursor: pointer;
-  position: relative;
-  text-decoration: none;
+const MarkdownParagraph: MDXComponents['p'] = ({ children }) => (
+  <p style={{ paddingBottom: '1rem' }}>{children}</p>
+);
 
-  &:after {
-    position: absolute;
-    z-index: -1;
-    bottom: 0px;
-    left: 50%;
-    transform: translateX(-50%);
-    content: '';
-    width: 100%;
-    height: 3px;
-    background-color: ${({ theme }) => theme.colors.secondary};
-    transition: all 250ms;
-  }
+const MarkdownList: MDXComponents['ol'] = ({ children }) => (
+  <ol style={{ margin: 0 }}>{children}</ol>
+);
 
-  &:hover {
-    color: ${({ theme }) => theme.colors.background};
+const MarkdownUnorderedList: MDXComponents['ul'] = ({ children }) => (
+  <ul style={{ margin: 0 }}>{children}</ul>
+);
 
-    &::after {
-      height: 110%;
-      width: 110%;
-    }
-  }
-`;
+const MarkdownListItem: MDXComponents['li'] = ({ children }) => (
+  <li style={{ marginBottom: '1rem' }}>{children}</li>
+);
 
-const MarkdownParagraph = styled(Text)`
-  padding-bottom: 1em;
-`;
-
-const MarkdownList = styled.ul`
-  margin: 0;
-`;
-
-const MarkdownListItem = styled.li`
-  margin-bottom: 1em;
-`;
-
-/* eslint-disable @typescript-eslint/no-explicit-any */
-const MarkdownLink = (
-  props: PropsWithChildren<any>,
-): ReactElement<any, any> => {
+const MarkdownLink: MDXComponents['a'] = props => {
   const href = props['href'] as string;
   const isInnerLink = href.startsWith('#');
 
   return isInnerLink ? (
-    <StyledLink href={href}>{props.children}</StyledLink>
+    <GatsbyLink to={href}>{props.children}</GatsbyLink>
   ) : (
-    <StyledLink href={href} target="_blank" rel="noreferrer">
+    <MaterialLink href={href} target="_blank" rel="noreferrer">
       {props.children}
-    </StyledLink>
+    </MaterialLink>
   );
 };
-/* eslint-enable @typescript-eslint/no-explicit-any */
 
 export const StyledMDXComponents: MDXComponents = {
   p: MarkdownParagraph,
   ol: MarkdownList,
+  ul: MarkdownUnorderedList,
   li: MarkdownListItem,
   a: MarkdownLink,
 };

--- a/src/components/description/MDXPanel.tsx
+++ b/src/components/description/MDXPanel.tsx
@@ -15,7 +15,7 @@
  */
 import React, { FC } from 'react';
 
-import { Box } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 
 import { Fade } from 'react-awesome-reveal';
 import { MDXProvider } from '@mdx-js/react';
@@ -31,10 +31,12 @@ export const MDXPanel: FC<MDXPanelProps> = ({ mdx, isFullPage }) => (
   <Box width={isFullPage ? [1, 1, 1] : [1, 1, 2 / 3]} px={[1, 2, 4]} mt={2}>
     <Fade direction="down" triggerOnce>
       <Box
-        fontSize={['medium', 'medium', 'large']}
+        //  fontSize={['medium', 'medium', 'large']}
         lineHeight={['1.5rem', '1.5rem', '2rem']}
       >
-        <MDXProvider components={StyledMDXComponents}>{mdx}</MDXProvider>
+        <Typography variant="body2">
+          <MDXProvider components={StyledMDXComponents}>{mdx}</MDXProvider>
+        </Typography>
       </Box>
     </Fade>
   </Box>

--- a/src/content/about_content_3.mdx
+++ b/src/content/about_content_3.mdx
@@ -1,4 +1,4 @@
-import { Box } from 'rebass/styled-components';
+import { Box } from '@mui/material';
 
 You can create and build applications to visualize:
 


### PR DESCRIPTION
Based on our team's decision, we no longer require approval of the refactoring pull request. Instead, we will review and approve the refactoring once all changes related to a specific component have been completed.

⚠️ The text can have not the same font size as the original design, due to the Typography of Material Kit.
It's possible to adjust after all changes are done in the end.

Covers https://github.com/process-analytics/process-analytics.dev/issues/831