### PR TITLE
chore(gatsby): update the gastby configuration

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -54,7 +54,10 @@ const config: GatsbyConfig = {
       resolve: `gatsby-plugin-google-gtag`,
       options: {
         trackingIds: [
-          process.env.GATSBY_GA_MEASUREMENT_ID, // Google Analytics
+          process.env.GATSBY_GA_MEASUREMENT_ID ??
+            (process.env.NODE_ENV !== 'production'
+              ? 'No id for development mode'
+              : undefined), // Google Analytics
         ],
         // This object gets passed directly to the gtag config command
         gtagConfig: {


### PR DESCRIPTION
Change the gastby configuration for `gatsby-plugin-google-gtag` plugin when the website is build in development mode and there is no `trackingIds`.

ℹ️ Based on our team's decision, we no longer require approval of the refactoring pull request. Instead, we will review and approve the refactoring once all changes related to a specific component have been completed.

Closes #1140