### PR TITLE
chore: fix eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,24 +15,17 @@
  */
 
 import noticePlugin from "eslint-plugin-notice";
-import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
+import prettierRecommendedConfig from 'eslint-plugin-prettier/recommended';
 import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
-import eslintPluginImport from 'eslint-plugin-import';
-import * as eslintPluginMdx from 'eslint-plugin-mdx'
+import * as mdxPlugin from 'eslint-plugin-mdx';
+import importPlugin from 'eslint-plugin-import';
 
 /** @type {import('eslint').Linter.FlatConfig[]} */
 export default tseslint.config(
+    prettierRecommendedConfig, // Enables eslint-plugin-prettier, eslint-config-prettier and prettier/prettier. This will display prettier errors as ESLint errors.
     {
-        plugins: {
-            '@typescript-eslint': tseslint.plugin
-        },
-        extends: [
-            // eslint.configs.recommended,
-            eslintPluginPrettierRecommended, // Enables eslint-plugin-prettier, eslint-config-prettier and prettier/prettier. This will display prettier errors as ESLint errors.
-        ],
         languageOptions: {
-            parser: tseslint.parser,
             parserOptions: {
                 ecmaVersion: 2018, // Allows for the parsing of modern ECMAScript features
                 sourceType: 'module', // Allows for the use of imports
@@ -50,15 +43,16 @@ export default tseslint.config(
     },
 
     {
-        // disable type-aware linting on JS files
-        files: ['**/*.js'],
+        // disable type-aware linting on JS and markdown files
+        files: ['**/*.js', '**/*.mdx, **/*.md'],
         ...tseslint.configs.disableTypeChecked,
     },
 
     // File-pattern specific overrides
     // javascript & typescript
     {
-        files: ['*.js', '*.ts', '*.tsx'],
+        files: ['**/*.js', '**/*.ts', '**/*.tsx'],
+        ...eslint.configs.recommended,
         plugins: {
             notice: noticePlugin
         },
@@ -78,7 +72,12 @@ export default tseslint.config(
     /** @type {import('@typescript-eslint/utils').TSESLint.FlatConfig.ConfigFile} */
     {
         files: ['**/*.ts', '**/*.tsx'],
-        extends: [...tseslint.configs.recommended, ...tseslint.configs.stylistic, eslintPluginImport.flatConfigs.recommended, eslintPluginImport.flatConfigs.typescript],
+        extends: [ // Feature of `typescript-eslint` to extend multiple configs: https://typescript-eslint.io/packages/typescript-eslint/#flat-config-extends
+            ...tseslint.configs.recommended,
+            ...tseslint.configs.stylistic,
+        ],
+        ...importPlugin.flatConfigs.recommended,
+        ...importPlugin.flatConfigs.typescript,
         settings: {
             'import/resolver': {
                 typescript: {
@@ -127,16 +126,16 @@ export default tseslint.config(
 
     // markdown
     {
-        ...eslintPluginMdx.flat,
+        ...mdxPlugin.flat,
         // optional, if you want to lint code blocks at the same
-        processor: eslintPluginMdx.createRemarkProcessor({
+        processor: mdxPlugin.createRemarkProcessor({
             lintCodeBlocks: true,
         }),
     },
     {
-        ...eslintPluginMdx.flatCodeBlocks,
+        ...mdxPlugin.flatCodeBlocks,
         rules: {
-            ...eslintPluginMdx.rules,
+            ...mdxPlugin.rules,
             // if you want to override some rules for code blocks
             'no-var': 'error',
             'prefer-const': 'error',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -25,25 +25,19 @@ import importPlugin from 'eslint-plugin-import';
 export default tseslint.config(
     prettierRecommendedConfig, // Enables eslint-plugin-prettier, eslint-config-prettier and prettier/prettier. This will display prettier errors as ESLint errors.
     {
+    	// Actually, the new feature to ignore folders in conf file or in commande line, seems to not work after several tests.
+    	// https://eslint.org/docs/latest/use/configure/ignore
+        ignores: [ ".cache/", "node_modules/",  "public/", "build/", ".github/", ".idea/", "/config/" ],
         languageOptions: {
             parserOptions: {
                 ecmaVersion: 2018, // Allows for the parsing of modern ECMAScript features
                 sourceType: 'module', // Allows for the use of imports
             },
         },
-        ignores: [
-            '.cache/',
-            'node_modules/',
-            'public/',
-            'build/',
-            '.github/',
-            '.idea/',
-            '/config/',
-        ],
     },
 
+    // disable type-aware linting on JS and markdown files
     {
-        // disable type-aware linting on JS and markdown files
         files: ['**/*.js', '**/*.mdx, **/*.md'],
         ...tseslint.configs.disableTypeChecked,
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,23 +23,10 @@ import importPlugin from 'eslint-plugin-import';
 
 /** @type {import('eslint').Linter.FlatConfig[]} */
 export default tseslint.config(
-    prettierRecommendedConfig, // Enables eslint-plugin-prettier, eslint-config-prettier and prettier/prettier. This will display prettier errors as ESLint errors.
     {
     	// Actually, the new feature to ignore folders in conf file or in commande line, seems to not work after several tests.
     	// https://eslint.org/docs/latest/use/configure/ignore
         ignores: [ ".cache/", "node_modules/",  "public/", "build/", ".github/", ".idea/", "/config/" ],
-        languageOptions: {
-            parserOptions: {
-                ecmaVersion: 2018, // Allows for the parsing of modern ECMAScript features
-                sourceType: 'module', // Allows for the use of imports
-            },
-        },
-    },
-
-    // disable type-aware linting on JS and markdown files
-    {
-        files: ['**/*.js', '**/*.mdx, **/*.md'],
-        ...tseslint.configs.disableTypeChecked,
     },
 
     // File-pattern specific overrides
@@ -47,8 +34,15 @@ export default tseslint.config(
     {
         files: ['**/*.js', '**/*.ts', '**/*.tsx'],
         ...eslint.configs.recommended,
+        ...prettierRecommendedConfig, // Enables eslint-plugin-prettier, eslint-config-prettier and prettier/prettier. This will display prettier errors as ESLint errors.
         plugins: {
             notice: noticePlugin
+        },
+        languageOptions: {
+            parserOptions: {
+                ecmaVersion: 2018, // Allows for the parsing of modern ECMAScript features
+                sourceType: 'module', // Allows for the use of imports
+            },
         },
         rules: {
             'notice/notice': [
@@ -60,6 +54,12 @@ export default tseslint.config(
             ],
             'no-console': ['error', { allow: ['warn', 'error'] }],
         },
+    },
+
+    // disable type-aware linting on JS and markdown files
+    {
+        files: ['**/*.js', '**/*.mdx, **/*.md'],
+        ...tseslint.configs.disableTypeChecked,
     },
 
     // typescript

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "eslint-import-resolver-typescript": "^3.6.3",
         "eslint-mdx": "^3.1.5",
         "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-import-x": "^4.3.1",
         "eslint-plugin-mdx": "^3.1.5",
         "eslint-plugin-notice": "^1.0.0-eslint9",
         "eslint-plugin-prettier": "^5.2.1",
@@ -12179,6 +12180,198 @@
       },
       "peerDependencies": {
         "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-import-x": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.3.1.tgz",
+      "integrity": "sha512-5TriWkXulDl486XnYYRgsL+VQoS/7mhN/2ci02iLCuL7gdhbiWxnsuL/NTcaKY9fpMgsMFjWZBtIGW7pb+RX0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.1.0",
+        "debug": "^4.3.4",
+        "doctrine": "^3.0.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "get-tsconfig": "^4.7.3",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.3",
+        "semver": "^7.6.3",
+        "stable-hash": "^0.0.4",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.12.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.12.2.tgz",
+      "integrity": "sha512-gPLpLtrj9aMHOvxJkSbDBmbRuYdtiEbnvO25bCMza3DhMjTQw0u7Y1M+YR5JPbMsXXnSPuCf5hfq0nEkQDL/JQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.12.2",
+        "@typescript-eslint/visitor-keys": "8.12.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/@typescript-eslint/types": {
+      "version": "8.12.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.12.2.tgz",
+      "integrity": "sha512-VwDwMF1SZ7wPBUZwmMdnDJ6sIFk4K4s+ALKLP6aIQsISkPv8jhiw65sAK6SuWODN/ix+m+HgbYDkH+zLjrzvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.12.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.12.2.tgz",
+      "integrity": "sha512-mME5MDwGe30Pq9zKPvyduyU86PH7aixwqYR2grTglAdB+AN8xXQ1vFGpYaUSJ5o5P/5znsSBeNcs5g5/2aQwow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "8.12.2",
+        "@typescript-eslint/visitor-keys": "8.12.2",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/@typescript-eslint/utils": {
+      "version": "8.12.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.12.2.tgz",
+      "integrity": "sha512-UTTuDIX3fkfAz6iSVa5rTuSfWIYZ6ATtEocQ/umkRSyC9O919lbZ8dcH7mysshrCdrAM03skJOEYaBugxN+M6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "8.12.2",
+        "@typescript-eslint/types": "8.12.2",
+        "@typescript-eslint/typescript-estree": "8.12.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.12.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.12.2.tgz",
+      "integrity": "sha512-PChz8UaKQAVNHghsHcPyx1OMHoFRUEA7rJSK/mDhdq85bk+PLsUHUBqTQTFt18VJZbmxBovM65fezlheQRsSDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.12.2",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/eslint-plugin-import/node_modules/debug": {
@@ -30363,6 +30556,13 @@
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
       "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stable-hash": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.4.tgz",
+      "integrity": "sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "serve": "gatsby serve",
     "clean": "gatsby clean",
     "check-types": "tsc -p . --noEmit",
-    "lint": "eslint \"*/**/*.{js,ts,tsx,mdx}\" --max-warnings 0 --fix",
-    "lint-check": "eslint \"*/**/*.{js,ts,tsx,mdx}\" --max-warnings 0",
+    "lint": "eslint \"{src/**,.}/*.{js,ts,tsx,mdx}\" --max-warnings 0 --fix",
+    "lint-check": "eslint \"{src/**,.}/*.{js,ts,tsx,mdx}\" --max-warnings 0",
     "prepare": "husky"
   },
   "dependencies": {


### PR DESCRIPTION
*   use [extends](https://typescript-eslint.io/packages/typescript-eslint/#flat-config-extends) feature of typescript-eslint only on `tseslint.configs.recommended` and `tseslint.configs.stylistic`, because there are not by default apply on Typescript files and the Eslint way to apply on those files doesn't work.
* avoid unnecessary configuration of plugin and parser.
* execute eslint only on files of `src` folder and on root files, not `build` or `node_modules`.

Actually, the new feature to ignore folders in conf file or in commande line, seems to not work after several tests: https://eslint.org/docs/latest/use/configure/ignore.
