### PR TITLE
refactor: replace deprecated types

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -25,6 +25,7 @@
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
  */
 
+import type {JSX} from 'react';
 import React from 'react';
 
 // @mui material components

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type {JSX} from 'react';
 import React from 'react';
 
 import type { SvgIcon } from '@mui/material';

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { PropsWithChildren } from 'react';
+import type {PropsWithChildren, JSX} from 'react';
 import React, { useEffect } from 'react';
 
 import { CssBaseline, ThemeProvider } from '@mui/material';

--- a/src/components/PageWithPosts.tsx
+++ b/src/components/PageWithPosts.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type {JSX} from "react";
 import * as React from 'react';
 
 import type { PostContent, FooterContent, HeaderContent } from '../components';

--- a/src/components/PostContainer.tsx
+++ b/src/components/PostContainer.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type {JSX} from 'react';
 import React from 'react';
 
 import { Box, Container, Grid } from '@mui/material';

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { PropsWithChildren } from 'react';
+import type {PropsWithChildren, JSX} from 'react';
 import React from 'react';
 
 import { ThemeProvider } from '@mui/material';

--- a/src/components/SocialLink.tsx
+++ b/src/components/SocialLink.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type {JSX} from 'react';
 import React from 'react';
 
 import type { LinkProps } from '@mui/material';

--- a/src/components/description/DescriptionPanel.tsx
+++ b/src/components/description/DescriptionPanel.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { FC } from 'react';
+import type {FC, JSX} from 'react';
 import React from 'react';
 
 import { Box } from '@mui/material';

--- a/src/components/description/MDXPanel.tsx
+++ b/src/components/description/MDXPanel.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { FC } from 'react';
+import type {FC, JSX} from 'react';
 import React from 'react';
 
 import { Box, Typography } from '@mui/material';

--- a/src/components/material-kit/Card/LibraryCard.tsx
+++ b/src/components/material-kit/Card/LibraryCard.tsx
@@ -28,6 +28,7 @@ Coded by www.creative-tim.com
 
 * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 */
+import type {JSX} from 'react';
 import React from 'react';
 
 // @mui material components

--- a/src/components/material-kit/Card/PostCard.tsx
+++ b/src/components/material-kit/Card/PostCard.tsx
@@ -28,6 +28,7 @@ Coded by www.creative-tim.com
 
 * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 */
+import type {JSX} from 'react';
 import React from 'react';
 
 // @mui material components

--- a/src/components/material-kit/MKBox/MKBox.tsx
+++ b/src/components/material-kit/MKBox/MKBox.tsx
@@ -24,7 +24,8 @@
  =========================================================
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
  */
-import React, { forwardRef } from 'react';
+import type {JSX} from "react";
+import React, {forwardRef} from 'react';
 
 import type { BoxTypeMap } from '@mui/system';
 import type { BoxProps as MuiBoxProps } from '@mui/material';

--- a/src/components/material-kit/Navbar/common/ActionButton.tsx
+++ b/src/components/material-kit/Navbar/common/ActionButton.tsx
@@ -28,6 +28,7 @@
 
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
  */
+import type {JSX} from 'react';
 import React from 'react';
 
 import type { ButtonProps } from '@mui/material';

--- a/src/components/material-kit/Navbar/common/NavbarItem.tsx
+++ b/src/components/material-kit/Navbar/common/NavbarItem.tsx
@@ -25,7 +25,7 @@
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
  */
 
-import type { PropsWithChildren } from 'react';
+import type {PropsWithChildren, JSX} from 'react';
 import React from 'react';
 
 // @mui material components

--- a/src/components/material-kit/Navbar/desktop/DropdownDropdown.tsx
+++ b/src/components/material-kit/Navbar/desktop/DropdownDropdown.tsx
@@ -25,7 +25,7 @@
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
  */
 
-import type { Dispatch, SetStateAction } from 'react';
+import type {Dispatch, JSX, SetStateAction} from 'react';
 import React from 'react';
 
 import { Grow, Popper } from '@mui/material';

--- a/src/components/material-kit/Navbar/desktop/DropdownLink.tsx
+++ b/src/components/material-kit/Navbar/desktop/DropdownLink.tsx
@@ -25,6 +25,7 @@
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
  */
 
+import type {JSX} from 'react';
 import React from 'react';
 
 import type { Theme } from '@mui/material';

--- a/src/components/material-kit/Navbar/desktop/NavbarNav.tsx
+++ b/src/components/material-kit/Navbar/desktop/NavbarNav.tsx
@@ -25,7 +25,7 @@
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
  */
 
-import type { Dispatch, SetStateAction } from 'react';
+import type {Dispatch, JSX, SetStateAction} from 'react';
 import React from 'react';
 
 import type { HoverStyle } from '../common';

--- a/src/components/material-kit/Navbar/mobile/DropdownDropdown.tsx
+++ b/src/components/material-kit/Navbar/mobile/DropdownDropdown.tsx
@@ -25,6 +25,7 @@
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
  */
 
+import type {JSX} from 'react';
 import React from 'react';
 
 import type { Theme } from '@mui/material';

--- a/src/components/material-kit/Navbar/mobile/DropdownLink.tsx
+++ b/src/components/material-kit/Navbar/mobile/DropdownLink.tsx
@@ -25,6 +25,7 @@
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
  */
 
+import type {JSX} from 'react';
 import React from 'react';
 
 import type { Theme } from '@mui/material';

--- a/src/components/material-kit/Navbar/mobile/NavDropdown.tsx
+++ b/src/components/material-kit/Navbar/mobile/NavDropdown.tsx
@@ -25,6 +25,7 @@
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
  */
 
+import type {JSX} from 'react';
 import React from 'react';
 
 import type { HeaderRouteWithMenus } from '../../../Header';

--- a/src/components/material-kit/Navbar/mobile/NavbarButton.tsx
+++ b/src/components/material-kit/Navbar/mobile/NavbarButton.tsx
@@ -29,6 +29,7 @@
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
  */
 
+import type {JSX} from 'react';
 import React from 'react';
 
 import { Close, Menu } from '@mui/icons-material';

--- a/src/components/material-kit/Navbar/mobile/NavbarNav.tsx
+++ b/src/components/material-kit/Navbar/mobile/NavbarNav.tsx
@@ -24,7 +24,8 @@
  =========================================================
  * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
  */
-import React, { useState } from 'react';
+import type {JSX} from 'react';
+import React, { useState} from 'react';
 
 // @mui material components
 import { Collapse } from '@mui/material';

--- a/src/components/modelGenerationApp/Features.tsx
+++ b/src/components/modelGenerationApp/Features.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { FC, PropsWithChildren } from 'react';
+import type {FC, PropsWithChildren, JSX} from 'react';
 import React from 'react';
 
 import type { BoxProps } from '@mui/material';

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { FC } from 'react';
+import type {FC, JSX} from 'react';
 import React from 'react';
 
 import type { HeadProps } from 'gatsby';

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type {JSX} from "react";
 import * as React from 'react';
 
 import type { HeadProps } from 'gatsby';

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type {JSX} from "react";
 import * as React from 'react';
 import type { HeadProps } from 'gatsby';
 

--- a/src/pages/news.tsx
+++ b/src/pages/news.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type {JSX} from "react";
 import * as React from 'react';
 
 import type { HeadProps } from 'gatsby';

--- a/src/sections/SectionWithPosts.tsx
+++ b/src/sections/SectionWithPosts.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type {JSX} from 'react';
 import React from 'react';
 
 import type { PostContent } from '../components';

--- a/src/sections/home/About.tsx
+++ b/src/sections/home/About.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type {JSX} from 'react';
 import React from 'react';
 
 import { aboutContent } from '../../content';

--- a/src/sections/home/Blog.tsx
+++ b/src/sections/home/Blog.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type {JSX} from 'react';
 import React from 'react';
 
 import { postsContent } from '../../content';

--- a/src/sections/home/Landing.tsx
+++ b/src/sections/home/Landing.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type {JSX} from 'react';
 import React from 'react';
 
 import type { Theme } from '@mui/material';

--- a/src/sections/home/Libraries.tsx
+++ b/src/sections/home/Libraries.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type {JSX} from 'react';
 import React from 'react';
 
 import { Container, Grid } from '@mui/material';

--- a/src/sections/home/News.tsx
+++ b/src/sections/home/News.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type {JSX} from 'react';
 import React from 'react';
 
 import { newsContent } from '../../content';


### PR DESCRIPTION
As we remove dependabot configuration and https://github.com/process-analytics/process-analytics.dev/pull/1375 fails because gatsby doesn't support this typescript version, we will close https://github.com/process-analytics/process-analytics.dev/pull/1375, but keep the refactoring done.