### PR TITLE
ci: use repo variable to use same ubuntu runner in all workflows

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ vars.RUNNER_UBUNTU }}
     steps:
       - uses: actions/checkout@v4
       - name: Build Setup

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ vars.RUNNER_UBUNTU }}
     steps:
       - uses: actions/checkout@v4
       - name: Build Setup

--- a/.github/workflows/generate-site-preview.yml
+++ b/.github/workflows/generate-site-preview.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   site_preview:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ vars.RUNNER_UBUNTU }}
     steps:
       - uses: bonitasoft/actions/packages/surge-preview-tools@v3
         id: surge-preview-tools

--- a/.github/workflows/pr-metadata-checks.yml
+++ b/.github/workflows/pr-metadata-checks.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   pr-title:
     if: contains(fromJSON('["opened", "edited", "reopened"]'), github.event.action)
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.RUNNER_UBUNTU }}
     permissions:
       pull-requests: write # post comments when the PR title doesn't match the "Conventional Commits" rules
     steps:
@@ -16,7 +16,7 @@ jobs:
 
   add-labels:
     if: contains(fromJSON('["opened", "synchronize", "reopened"]'), github.event.action)
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.RUNNER_UBUNTU }}
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Covers #821